### PR TITLE
Add policy management services

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
     </dependency>
     <dependency>
       <groupId>com.rackspace.salus</groupId>
-      <artifactId>salus-telemetry-protocol</artifactId>
-      <version>0.1.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-model</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,9 @@
     <relativePath>../salus-app-base</relativePath>
   </parent>
 
-  <artifactId>salus-policy-management</artifactId>
+  <artifactId>salus-telemetry-policy-management</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <name>salus-policy-management</name>
+  <name>salus-telemetry-policy-management</name>
   <description>Service for managing policies</description>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Rackspace US, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.rackspace.salus</groupId>
+    <artifactId>salus-app-base</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../salus-app-base</relativePath>
+  </parent>
+
+  <artifactId>salus-policy-management</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>salus-policy-management</name>
+  <description>Service for managing policies</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-protocol</artifactId>
+      <version>0.1.1</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-resource-management</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <classifier>client</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-monitor-management</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <classifier>client</classifier>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-core</artifactId>
+      <version>1.5.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.co.jemos.podam</groupId>
+      <artifactId>podam</artifactId>
+      <version>7.2.1.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-test</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-tools</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build-info</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.2</version>
+        <executions>
+          <execution>
+            <id>client-jar</id>
+            <goals><goal>jar</goal></goals>
+            <configuration>
+              <classifier>client</classifier>
+              <includes>
+                <include>**/web/client/**</include>
+                <include>**/web/model/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.github.kongchen</groupId>
+        <artifactId>swagger-maven-plugin</artifactId>
+        <version>3.1.8</version>
+        <configuration>
+          <apiSources>
+            <apiSource>
+              <springmvc>true</springmvc>
+              <locations>
+                <location>com.rackspace.salus.policy.manage.web.model</location>
+                <location>com.rackspace.salus.policy.manage.web.controller.PolicyApiController</location>
+              </locations>
+              <templatePath>${basedir}/templates/strapdown.html.hbs</templatePath>
+              <schemes>
+                <scheme>https</scheme>
+                <scheme>http</scheme>
+              </schemes>
+              <info>
+                <title>Salus Monitor Management</title>
+                <version>0.1.0</version>
+              </info>
+              <outputPath>${project.build.directory}/generated/swagger/document.html</outputPath>
+              <swaggerDirectory>${project.build.directory}/generated/swagger</swaggerDirectory>
+              <outputFormats>json</outputFormats>
+            </apiSource>
+          </apiSources>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-hibernate-validations</artifactId>
+            <version>1.5.6</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.2.1</version>
+        <executions>
+          <execution>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classpathScope>test</classpathScope>
+          <mainClass>com.rackspace.salus.salus_tools.converter.SwaggerJsonConverter</mainClass>
+          <arguments>
+            <argument>${project.build.directory}/generated/swagger</argument>
+            <argument>${basedir}/templates/strapdown.html.hbs</argument>
+            <argument>/tenant/{tenantId}=</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>salus-dev-snapshots</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
+    <repository>
+      <id>salus-dev-release</id>
+      <url>https://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release-local</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>salus-dev-release</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </repository>
+    <repository>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>salus-dev-release</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-release</url>
+    </pluginRepository>
+    <pluginRepository>
+      <snapshots />
+      <id>salus-dev-snapshots</id>
+      <url>http://salus-artifactory.dev.monplat.rackspace.net/artifactory/libs-snapshot</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+
+
+</project>
+

--- a/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
@@ -17,15 +17,14 @@
 package com.rackspace.salus.policy.manage;
 
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
+import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.util.DumpConfigProperties;
-import com.rackspace.salus.common.web.ExtendedErrorAttributesConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Import;
 
 @SpringBootApplication
 @EnableSalusKafkaMessaging
-@Import(ExtendedErrorAttributesConfig.class)
+@EnableExtendedErrorAttributes
 public class PolicyManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage;
+
+import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
+import com.rackspace.salus.common.util.DumpConfigProperties;
+import com.rackspace.salus.common.web.ExtendedErrorAttributesConfig;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+@SpringBootApplication
+@EnableSalusKafkaMessaging
+@Import(ExtendedErrorAttributesConfig.class)
+public class PolicyManagementApplication {
+
+  public static void main(String[] args) {
+    DumpConfigProperties.process(args);
+
+    SpringApplication.run(PolicyManagementApplication.class, args);
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/config/RestClientsConfig.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/config/RestClientsConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.monitor_management.web.client.MonitorApi;
+import com.rackspace.salus.monitor_management.web.client.MonitorApiClient;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.resource_management.web.client.ResourceApiClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RestClientsConfig {
+
+  private final ServicesProperties servicesProperties;
+
+  @Autowired
+  public RestClientsConfig(ServicesProperties servicesProperties) {
+    this.servicesProperties = servicesProperties;
+  }
+
+  @Bean
+  public ResourceApi resourceApi(RestTemplateBuilder restTemplateBuilder, ObjectMapper objectMapper) {
+    return new ResourceApiClient(objectMapper,
+        restTemplateBuilder.rootUri(servicesProperties.getResourceManagementUrl())
+            .build()
+    );
+  }
+
+  @Bean
+  public MonitorApi monitorApi(RestTemplateBuilder restTemplateBuilder) {
+    return new MonitorApiClient(
+        restTemplateBuilder.rootUri(servicesProperties.getMonitorManagementUrl())
+            .build()
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/config/ServicesProperties.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/config/ServicesProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties("salus.services")
+@Component
+@Data
+public class ServicesProperties {
+  String monitorManagementUrl;
+  String resourceManagementUrl;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.entities;
+
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
+import java.time.format.DateTimeFormatter;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import lombok.Data;
+import org.hibernate.validator.constraints.NotBlank;
+
+@Entity
+@Table(name = "policy_monitors")
+@Data
+public class MonitorPolicy extends Policy {
+
+  @NotBlank
+  @Column(name="name")
+  String name;
+
+  @NotBlank
+  @Column(name="monitor_id")
+  String monitorId;
+
+  @Override
+  public PolicyDTO toDTO() {
+    return new MonitorPolicyDTO()
+        .setMonitorId(monitorId)
+        .setName(name)
+        .setSubscope(subscope)
+        .setScope(scope)
+        .setId(id)
+        .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(createdTimestamp))
+        .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(updatedTimestamp));
+  }
+}
+

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
@@ -23,11 +23,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "policy_monitors")
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class MonitorPolicy extends Policy {
 
   @NotBlank

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/MonitorPolicy.java
@@ -50,4 +50,3 @@ public class MonitorPolicy extends Policy {
         .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(updatedTimestamp));
   }
 }
-

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/Policy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/Policy.java
@@ -42,7 +42,6 @@ import org.hibernate.annotations.UpdateTimestamp;
     strategy = InheritanceType.JOINED
 )
 @Data
-@ValidPolicy
 public abstract class Policy implements Serializable {
   @Id
   @GeneratedValue

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/Policy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/Policy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.entities;
+
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.model.validator.ValidPolicy;
+import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Table(name = "policies")
+@Inheritance(
+    strategy = InheritanceType.JOINED
+)
+@Data
+@ValidPolicy
+public abstract class Policy implements Serializable {
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @NotNull
+  @Enumerated(EnumType.STRING)
+  @Column(name="scope")
+  Scope scope;
+
+  @Column(name="subscope")
+  String subscope;
+
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+
+  public abstract PolicyDTO toDTO();
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -26,6 +26,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.Index;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -36,7 +37,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
-@Table(name = "tenant_metadata")
+@Table(name = "tenant_metadata", indexes = {
+    @Index(name = "by_tenant", columnList = "tenant_id")
+})
 @TypeDef(name = "json", typeClass = JsonStringType.class)
 @Data
 public class TenantMetadata {

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -52,6 +52,7 @@ public class TenantMetadata {
   public TenantMetadataDTO toDTO() {
     return new TenantMetadataDTO()
         .setId(id)
+        .setAccountType(accountType)
         .setTenantId(tenantId)
         .setMetadata(metadata)
         .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(createdTimestamp))

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -33,9 +33,12 @@ public class TenantMetadata {
   @Column(name = "tenant_id", unique = true)
   String tenantId;
 
+  @Column(name = "account_type")
+  String accountType;
+
   @NotNull
   @Type(type = "json")
-  @Column(columnDefinition = "json")
+  @Column(columnDefinition = "text")
   Map<String, String> metadata;
 
   @CreationTimestamp

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -2,6 +2,8 @@ package com.rackspace.salus.policy.manage.entities;
 
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.vladmihalcea.hibernate.type.json.JsonStringType;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -11,8 +13,10 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
@@ -34,10 +38,20 @@ public class TenantMetadata {
   @Column(columnDefinition = "json")
   Map<String, String> metadata;
 
+  @CreationTimestamp
+  @Column(name="created_timestamp")
+  Instant createdTimestamp;
+
+  @UpdateTimestamp
+  @Column(name="updated_timestamp")
+  Instant updatedTimestamp;
+
   public TenantMetadataDTO toDTO() {
     return new TenantMetadataDTO()
         .setId(id)
         .setTenantId(tenantId)
-        .setMetadata(metadata);
+        .setMetadata(metadata)
+        .setCreatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(createdTimestamp))
+        .setUpdatedTimestamp(DateTimeFormatter.ISO_INSTANT.format(updatedTimestamp));
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -1,0 +1,43 @@
+package com.rackspace.salus.policy.manage.entities;
+
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
+import com.vladmihalcea.hibernate.type.json.JsonStringType;
+import java.util.Map;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import org.hibernate.validator.constraints.NotBlank;
+
+@Entity
+@Table(name = "tenant_metadata")
+@TypeDef(name = "json", typeClass = JsonStringType.class)
+@Data
+public class TenantMetadata {
+  @Id
+  @GeneratedValue
+  @org.hibernate.annotations.Type(type="uuid-char")
+  UUID id;
+
+  @NotBlank
+  @Column(name = "tenant_id", unique = true)
+  String tenantId;
+
+  @NotNull
+  @Type(type = "json")
+  @Column(columnDefinition = "json")
+  Map<String, String> metadata;
+
+  public TenantMetadataDTO toDTO() {
+    return new TenantMetadataDTO()
+        .setId(id)
+        .setTenantId(tenantId)
+        .setMetadata(metadata);
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.policy.manage.entities;
 
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;

--- a/src/main/java/com/rackspace/salus/policy/manage/lombok.config
+++ b/src/main/java/com/rackspace/salus/policy/manage/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.accessors.chain = true

--- a/src/main/java/com/rackspace/salus/policy/manage/model/Scope.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/Scope.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.model;
+
+public enum Scope {
+  GLOBAL (0),
+  ACCOUNT_TYPE (1),
+  SLA (2),
+  TENANT (3);
+
+  private final int priority;
+  Scope (int priority) {
+    this.priority = priority;
+  }
+
+  public int getPriority() {
+    return this.priority;
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/TenantMetadataKeys.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/TenantMetadataKeys.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.model;
+
+public enum TenantMetadataKeys {
+  ACCOUNT_TYPE("AccountType");
+
+  private final String key;
+
+  TenantMetadataKeys(String key) { this.key = key; }
+
+  public String getKey() {
+    return this.key;
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/MonitorPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/MonitorPolicyCreateValidator.java
@@ -1,0 +1,15 @@
+package com.rackspace.salus.policy.manage.model.validator;
+
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+
+public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyCreate> {
+  @Override
+  protected Enum getScope(MonitorPolicyCreate policy) {
+    return policy.getScope();
+  }
+
+  @Override
+  protected boolean isSubscopeSet(MonitorPolicyCreate policy) {
+    return policy.getSubscope() != null && !policy.getSubscope().isBlank();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/MonitorPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/MonitorPolicyCreateValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.policy.manage.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyEntityValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyEntityValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.rackspace.salus.policy.manage.model.validator;
 
 import com.rackspace.salus.policy.manage.entities.Policy;

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyEntityValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyEntityValidator.java
@@ -1,0 +1,15 @@
+package com.rackspace.salus.policy.manage.model.validator;
+
+import com.rackspace.salus.policy.manage.entities.Policy;
+
+public class PolicyEntityValidator extends PolicyValidator<Policy> {
+  @Override
+  protected Enum getScope(Policy policy) {
+    return policy.getScope();
+  }
+
+  @Override
+  protected boolean isSubscopeSet(Policy policy) {
+    return policy.getSubscope() != null && !policy.getSubscope().isBlank();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/PolicyValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.model.validator;
+
+import com.rackspace.salus.policy.manage.model.Scope;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public abstract class PolicyValidator<T> implements ConstraintValidator<ValidPolicy, T> {
+  @Override
+  public void initialize(ValidPolicy constraint) { }
+
+  @Override
+  public boolean isValid(T value, ConstraintValidatorContext context) {
+    return
+        // true if scope is global and subset is not set
+        (getScope(value).equals(Scope.GLOBAL) && !isSubscopeSet(value)) ||
+            // or true if scope is not global and subset is set
+            (!getScope(value).equals(Scope.GLOBAL) && isSubscopeSet(value));
+  }
+
+  protected abstract Enum getScope(T value);
+  protected abstract boolean isSubscopeSet(T value);
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.model.validator;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+/**
+ * Declares that the annotated parameter or field must be a private zone name.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = {PolicyEntityValidator.class, MonitorPolicyCreateValidator.class})
+public @interface ValidPolicy {
+
+  String message() default "subscope must be set for any non-global policy";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
@@ -33,7 +33,7 @@ import javax.validation.Payload;
 @Constraint(validatedBy = {PolicyEntityValidator.class, MonitorPolicyCreateValidator.class})
 public @interface ValidPolicy {
 
-  String message() default "subscope must be set for any non-global policy";
+  String message() default "subscope must be set for any non-global policy but not for global policies";
 
   Class<?>[] groups() default {};
 

--- a/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicy.java
@@ -25,7 +25,7 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 
 /**
- * Declares that the annotated parameter or field must be a private zone name.
+ * Declares that the annotated class must have valid scope and subscope values set.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/com/rackspace/salus/policy/manage/repositories/MonitorPolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/repositories/MonitorPolicyRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.repositories;
+
+import com.rackspace.salus.policy.manage.entities.MonitorPolicy;
+import com.rackspace.salus.policy.manage.model.Scope;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface MonitorPolicyRepository extends PagingAndSortingRepository<MonitorPolicy, UUID> {
+
+  boolean existsByScopeAndSubscopeAndName(Scope scope, String subscope, String name);
+
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/repositories/PolicyRepository.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/repositories/PolicyRepository.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.repositories;
+
+import com.rackspace.salus.policy.manage.entities.Policy;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface PolicyRepository extends PagingAndSortingRepository<Policy, UUID> {
+
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/repositories/TenantMetadataRepository.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.repositories;
+
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import java.util.UUID;
+import org.springframework.data.repository.PagingAndSortingRepository;
+
+public interface TenantMetadataRepository extends PagingAndSortingRepository<TenantMetadata, UUID> {
+  TenantMetadata findByTenantId(String tenantId);
+}
+

--- a/src/main/java/com/rackspace/salus/policy/manage/repositories/TenantMetadataRepository.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/repositories/TenantMetadataRepository.java
@@ -17,10 +17,11 @@
 package com.rackspace.salus.policy.manage.repositories;
 
 import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.repository.PagingAndSortingRepository;
 
 public interface TenantMetadataRepository extends PagingAndSortingRepository<TenantMetadata, UUID> {
-  TenantMetadata findByTenantId(String tenantId);
+  Optional<TenantMetadata> findByTenantId(String tenantId);
 }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+
+import com.rackspace.salus.common.messaging.KafkaTopicProperties;
+import com.rackspace.salus.telemetry.messaging.PolicyEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class PolicyEventProducer {
+
+  private final KafkaTemplate<String,Object> kafkaTemplate;
+  private final KafkaTopicProperties properties;
+
+  @Autowired
+  public PolicyEventProducer(KafkaTemplate<String,Object> kafkaTemplate, KafkaTopicProperties properties) {
+    this.kafkaTemplate = kafkaTemplate;
+    this.properties= properties;
+  }
+
+  public void sendPolicyEvent(PolicyEvent event) {
+    final String topic = properties.getPolicies();
+
+    log.debug("Sending policyEvent={} on topic={}", event, topic);
+    kafkaTemplate.send(topic, buildMessageKey(event), event);
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -114,7 +114,7 @@ public class PolicyManagement {
    * @return The list of effective monitor policies that should be applied to the tenant's resources.
    */
   public List<Policy> getEffectiveMonitorPoliciesForTenant(String tenantId) {
-    return new ArrayList<>(
+    return
         // Create a stream from all monitor policies
         StreamSupport.stream(monitorPolicyRepository.findAll().spliterator(), false)
             // Filter the stream for only those policies relevant to this tenant
@@ -131,7 +131,7 @@ public class PolicyManagement {
             // Filter out any of the optional objects that do not contain anything
             .filter(Optional::isPresent).map(Optional::get)
             // Finally convert to a list of the relevant monitor policies
-            .collect(Collectors.toList()));
+            .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import com.rackspace.salus.monitor_management.web.client.MonitorApi;
+import com.rackspace.salus.policy.manage.entities.MonitorPolicy;
+import com.rackspace.salus.policy.manage.entities.Policy;
+import com.rackspace.salus.policy.manage.repositories.MonitorPolicyRepository;
+import com.rackspace.salus.policy.manage.repositories.PolicyRepository;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import java.util.Optional;
+import java.util.UUID;
+import javax.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PolicyManagement {
+
+  private final PolicyRepository policyRepository;
+  private final MonitorPolicyRepository monitorPolicyRepository;
+  private final MonitorApi monitorApi;
+
+  @Autowired
+  public PolicyManagement(
+      PolicyRepository policyRepository,
+      MonitorPolicyRepository monitorPolicyRepository,
+      MonitorApi monitorApi) {
+    this.policyRepository = policyRepository;
+    this.monitorPolicyRepository = monitorPolicyRepository;
+    this.monitorApi = monitorApi;
+  }
+
+  public Policy createMonitorPolicy(@Valid MonitorPolicyCreate create) {
+    if (exists(create)) {
+      throw new AlreadyExistsException(String.format("Policy already exists with scope:subscope:name of %s:%s:%s",
+          create.getScope(), create.getSubscope(), create.getName()));
+    }
+    if (!isValidMonitorId(create.getMonitorId())) {
+      throw new IllegalArgumentException(String.format("Invalid monitor id provided: %s",
+          create.getMonitorId()));
+    }
+    Policy policy = new MonitorPolicy()
+        .setMonitorId(create.getMonitorId())
+        .setName(create.getName())
+        .setSubscope(create.getSubscope())
+        .setScope(create.getScope());
+
+    policyRepository.save(policy);
+
+    return policy;
+  }
+
+  public Optional<Policy> getPolicy(UUID id) {
+    return policyRepository.findById(id);
+  }
+
+  public void removeMonitorPolicy(UUID id) {
+    Policy policy = getPolicy(id).orElseThrow(() ->
+        new NotFoundException(
+            String.format("No policy found with id %s", id)));
+
+    policyRepository.deleteById(id);
+  }
+
+  public boolean isValidMonitorId(String monitorId) {
+    //monitorApi.getPolicyMonitorById(monitorId)
+    return true; // temporary until monitor management is updated
+  }
+
+  public boolean exists(MonitorPolicyCreate policy) {
+    return monitorPolicyRepository.existsByScopeAndSubscopeAndName(
+        policy.getScope(), policy.getSubscope(), policy.getName());
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -168,8 +168,7 @@ public class PolicyManagement {
    * @return True if the monitor exists, otherwise false.
    */
   private boolean isValidMonitorId(String monitorId) {
-    //monitorApi.getPolicyMonitorById(monitorId)
-    return true; // temporary until monitor management is updated
+    return monitorApi.getPolicyMonitorById(monitorId) != null;
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -19,13 +19,28 @@ package com.rackspace.salus.policy.manage.services;
 import com.rackspace.salus.monitor_management.web.client.MonitorApi;
 import com.rackspace.salus.policy.manage.entities.MonitorPolicy;
 import com.rackspace.salus.policy.manage.entities.Policy;
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.model.TenantMetadataKeys;
 import com.rackspace.salus.policy.manage.repositories.MonitorPolicyRepository;
 import com.rackspace.salus.policy.manage.repositories.PolicyRepository;
+import com.rackspace.salus.policy.manage.repositories.TenantMetadataRepository;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -35,16 +50,25 @@ public class PolicyManagement {
 
   private final PolicyRepository policyRepository;
   private final MonitorPolicyRepository monitorPolicyRepository;
+  private final TenantMetadataRepository tenantMetadataRepository;
   private final MonitorApi monitorApi;
+  private final ResourceApi resourceApi;
+  private final PolicyEventProducer policyEventProducer;
 
   @Autowired
   public PolicyManagement(
       PolicyRepository policyRepository,
       MonitorPolicyRepository monitorPolicyRepository,
-      MonitorApi monitorApi) {
+      TenantMetadataRepository tenantMetadataRepository,
+      MonitorApi monitorApi,
+      ResourceApi resourceApi,
+      PolicyEventProducer policyEventProducer) {
     this.policyRepository = policyRepository;
     this.monitorPolicyRepository = monitorPolicyRepository;
+    this.tenantMetadataRepository = tenantMetadataRepository;
     this.monitorApi = monitorApi;
+    this.resourceApi = resourceApi;
+    this.policyEventProducer = policyEventProducer;
   }
 
   public Policy createMonitorPolicy(@Valid MonitorPolicyCreate create) {
@@ -63,6 +87,7 @@ public class PolicyManagement {
         .setScope(create.getScope());
 
     policyRepository.save(policy);
+    sendMonitorPolicyEvents((MonitorPolicy) policy);
 
     return policy;
   }
@@ -71,8 +96,48 @@ public class PolicyManagement {
     return policyRepository.findById(id);
   }
 
-  public void removeMonitorPolicy(UUID id) {
-    Policy policy = getPolicy(id).orElseThrow(() ->
+  /**
+   * Gets all the monitor policies relevant to a tenant.
+   *
+   * Filters the list of all policies down to those that fall into the correct scope/subscope for
+   * the provided tenant.
+   *
+   * @param tenantId The tenantId to retrieve policies for.
+   * @return The list of effective monitor policies that should be applied to the tenant's resources.
+   */
+  public List<Policy> getEffectiveMonitorPoliciesForTenant(String tenantId) {
+    String accountType = getAccountTypeByTenant(tenantId);
+
+    return new ArrayList<>(
+        // Create a stream from all monitor policies
+        StreamSupport.stream(monitorPolicyRepository.findAll().spliterator(), false)
+            // Filter the stream for only those policies relevant to this tenant
+            .filter(policy -> {
+              return policy.getScope().equals(Scope.GLOBAL) ||
+                  (policy.getScope().equals(Scope.ACCOUNT_TYPE) && policy.getSubscope().equals(accountType)) ||
+                  (policy.getScope().equals(Scope.TENANT) && policy.getSubscope().equals(tenantId));
+            })
+            // Get one policy for each policy name
+            .collect(
+                // First group the policies by name
+                Collectors.groupingBy(MonitorPolicy::getName,
+                    // then filter each group by only retrieving the one with the highest priority
+                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
+            )
+            // Now we have a map of policy name -> (optional) monitor policy
+            .values().stream()
+            // Filter out any of the optional objects that do not contain anything
+            .filter(Optional::isPresent).map(Optional::get)
+            // Finally convert to a list of the relevant monitor policies
+            .collect(Collectors.toList()));
+  }
+
+  private Iterable<MonitorPolicy> getAllMonitorPolicies() {
+    return monitorPolicyRepository.findAll();
+  }
+
+  public void removePolicy(UUID id) {
+    getPolicy(id).orElseThrow(() ->
         new NotFoundException(
             String.format("No policy found with id %s", id)));
 
@@ -87,5 +152,60 @@ public class PolicyManagement {
   public boolean exists(MonitorPolicyCreate policy) {
     return monitorPolicyRepository.existsByScopeAndSubscopeAndName(
         policy.getScope(), policy.getSubscope(), policy.getName());
+  }
+
+  /**
+   * Sends monitor policy events for all potentially relevant tenants.
+   * @param policy The MonitorPolicy to distribute out to all tenants.
+   */
+  private void sendMonitorPolicyEvents(MonitorPolicy policy) {
+    List<String> tenantIds = getAllDistinctTenantIds();
+    tenantIds.stream()
+        .map(tenantId -> new MonitorPolicyEvent()
+            .setMonitorId(policy.getMonitorId())
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId))
+        .forEach(policyEventProducer::sendPolicyEvent);
+  }
+
+  /**
+   *
+   * @param tenantId
+   * @return The accountType value for the tenant if it exists, otherwise null.
+   */
+  public String getAccountTypeByTenant(String tenantId) {
+    TenantMetadata metadata = tenantMetadataRepository.findByTenantId(tenantId);
+    if (metadata == null) {
+      return null;
+    }
+    return metadata.getMetadata().get(TenantMetadataKeys.ACCOUNT_TYPE.getKey());
+  }
+
+  public TenantMetadataDTO upsertTenantMetadata(String tenantId, String key, String value) {
+    TenantMetadata metadata = tenantMetadataRepository.findByTenantId(tenantId);
+
+    if (metadata == null) {
+      metadata = new TenantMetadata()
+          .setTenantId(tenantId)
+          .setMetadata(Collections.singletonMap(key, value));
+
+      tenantMetadataRepository.save(metadata);
+
+      return metadata.toDTO();
+    }
+
+    metadata.getMetadata().put(key, value);
+    tenantMetadataRepository.save(metadata);// need to verify that this saves the new values.  we might need to create a new map to store in the object vs. updating the existing one.
+
+    return metadata.toDTO();
+  }
+
+  /**
+   * Queries the ResourceAPI to retrieve all known tenants with at least one resource.
+   * @return A list of tenant ids.
+   */
+  private List<String> getAllDistinctTenantIds() {
+    //return resourceApi.getAllDistinctTenantIds();
+    return Collections.singletonList("aaaaaa");
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/TenantManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/TenantManagement.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import com.rackspace.salus.policy.manage.repositories.TenantMetadataRepository;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TenantManagement {
+
+  private final TenantMetadataRepository tenantMetadataRepository;
+
+  @Autowired
+  public TenantManagement(
+      TenantMetadataRepository tenantMetadataRepository) {
+    this.tenantMetadataRepository = tenantMetadataRepository;
+  }
+
+  /**
+   * Get the account type value for a tenant if it is set.
+   *
+   * @param tenantId The tenant to lookup.
+   * @return The accountType value for the tenant if it exists, otherwise null.
+   */
+  public String getAccountTypeByTenant(String tenantId) {
+    TenantMetadata metadata = tenantMetadataRepository.findByTenantId(tenantId);
+    if (metadata == null) {
+      return null;
+    }
+    return metadata.getAccountType();
+  }
+
+  /**
+   * Create or update the information stored relating to an individual tenant.
+   * @param tenantId The tenant to store this data under.
+   * @param input The data to alter.
+   * @return The full tenant information.
+   */
+  public TenantMetadataDTO upsertTenantMetadata(String tenantId, TenantMetadataCU input) {
+    TenantMetadata metadata = tenantMetadataRepository.findByTenantId(tenantId);
+
+    PropertyMapper map = PropertyMapper.get();
+    map.from(tenantId)
+        .to(metadata::setTenantId);
+    map.from(input.getAccountType())
+        .whenNonNull()
+        .to(metadata::setAccountType);
+    map.from(input.getMetadata())
+        .whenNonNull()
+        .to(metadata::setMetadata);
+
+    tenantMetadataRepository.save(metadata);
+
+    return metadata.toDTO();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.policy.manage.services.PolicyManagement;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
+import com.rackspace.salus.telemetry.model.View;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class PolicyApiController {
+
+  private PolicyManagement policyManagement;
+
+  @Autowired
+  public PolicyApiController(
+      PolicyManagement policyManagement) {
+    this.policyManagement = policyManagement;
+  }
+
+  @PostMapping("/admin/policy/monitors")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates new Monitor for Tenant")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
+  @JsonView(View.Admin.class)
+  public PolicyDTO create(@Valid @RequestBody final MonitorPolicyCreate input)
+      throws IllegalArgumentException {
+    return policyManagement.createMonitorPolicy(input).toDTO();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
@@ -21,15 +21,12 @@ import com.rackspace.salus.policy.manage.entities.Policy;
 import com.rackspace.salus.policy.manage.services.PolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
-import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
-import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -40,7 +37,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -94,13 +90,5 @@ public class PolicyApiController {
   @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID uuid) {
     policyManagement.removePolicy(uuid);
-  }
-
-  @PutMapping("/public/{tenantId}/account")
-  @ApiOperation(value = "Creates new Monitor for Tenant")
-  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
-  public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
-                                                @RequestBody TenantMetadataCU input) {
-    return policyManagement.upsertTenantMetadata(tenantId, input);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
@@ -17,17 +17,26 @@
 package com.rackspace.salus.policy.manage.web.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.policy.manage.entities.Policy;
 import com.rackspace.salus.policy.manage.services.PolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,6 +56,24 @@ public class PolicyApiController {
     this.policyManagement = policyManagement;
   }
 
+  @GetMapping("/admin/policy/monitors/{uuid}")
+  @ApiOperation(value = "Gets specific Policy by id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policy Retrieved")})
+  @JsonView(View.Admin.class)
+  public PolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
+    return policyManagement.getPolicy(uuid).orElseThrow(
+        () -> new NotFoundException(String.format("No policy found with id %s", uuid))).toDTO();
+  }
+
+  @GetMapping("/admin/policy/monitors/effective/{tenantId}")
+  @ApiOperation(value = "Gets effective monitor policies by tenant id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
+  @JsonView(View.Admin.class)
+  public List<PolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
+    return policyManagement.getEffectiveMonitorPoliciesForTenant(tenantId)
+        .stream().map(Policy::toDTO).collect(Collectors.toList());
+  }
+
   @PostMapping("/admin/policy/monitors")
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new Monitor for Tenant")
@@ -55,5 +82,14 @@ public class PolicyApiController {
   public PolicyDTO create(@Valid @RequestBody final MonitorPolicyCreate input)
       throws IllegalArgumentException {
     return policyManagement.createMonitorPolicy(input).toDTO();
+  }
+
+  @DeleteMapping("/admin/policy/monitors/{uuid}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiOperation(value = "Deletes specific Policy")
+  @ApiResponses(value = { @ApiResponse(code = 204, message = "Policy Deleted")})
+  @JsonView(View.Admin.class)
+  public void delete(@PathVariable UUID uuid) {
+    policyManagement.removePolicy(uuid);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiController.java
@@ -21,13 +21,15 @@ import com.rackspace.salus.policy.manage.entities.Policy;
 import com.rackspace.salus.policy.manage.services.PolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.PolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.telemetry.model.PagedContent;
 import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -38,6 +40,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -91,5 +94,13 @@ public class PolicyApiController {
   @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID uuid) {
     policyManagement.removePolicy(uuid);
+  }
+
+  @PutMapping("/public/{tenantId}/account")
+  @ApiOperation(value = "Creates new Monitor for Tenant")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
+  public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
+                                                @RequestBody TenantMetadataCU input) {
+    return policyManagement.upsertTenantMetadata(tenantId, input);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
@@ -27,7 +27,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-@ControllerAdvice(basePackages = "com.rackspace.salus.monitor_management.web")
+@ControllerAdvice(basePackages = "com.rackspace.salus.policy.manage.web")
 @ResponseBody
 public class RestExceptionHandler extends
     com.rackspace.salus.common.web.AbstractRestExceptionHandler {

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.error.ErrorAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice(basePackages = "com.rackspace.salus.monitor_management.web")
+@ResponseBody
+public class RestExceptionHandler extends
+    com.rackspace.salus.common.web.AbstractRestExceptionHandler {
+
+  @Autowired
+  public RestExceptionHandler(ErrorAttributes errorAttributes) {
+    super(errorAttributes);
+  }
+
+  @ExceptionHandler({IllegalArgumentException.class})
+  public ResponseEntity<?> handleBadRequest(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler({NotFoundException.class})
+  public ResponseEntity<?> handleNotFound(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler({AlreadyExistsException.class})
+  public ResponseEntity<?> handleAlreadyExists(
+      HttpServletRequest request) {
+    return respondWith(request, HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import com.rackspace.salus.policy.manage.services.TenantManagement;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class TenantApiController {
+
+  private TenantManagement tenantManagement;
+
+  @Autowired
+  public TenantApiController(
+      TenantManagement tenantManagement) {
+    this.tenantManagement = tenantManagement;
+  }
+
+  @PutMapping("/public/{tenantId}/account")
+  @ApiOperation(value = "Creates or updates miscellaneous information stored for a particular tenant")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
+  public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
+      @RequestBody TenantMetadataCU input) {
+    return tenantManagement.upsertTenantMetadata(tenantId, input);
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyCreate.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.model.validator.ValidPolicy;
+import java.io.Serializable;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+import org.hibernate.validator.constraints.NotBlank;
+
+/**
+ * This Object is used for handling the creation of Monitor Policies.
+ */
+@Data
+@ValidPolicy
+public class MonitorPolicyCreate implements Serializable {
+  @NotNull
+  Scope scope;
+
+  String subscope;
+
+  @NotBlank
+  String name;
+
+  @NotBlank
+  String monitorId;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyDTO.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import lombok.Data;
+
+@Data
+public class MonitorPolicyDTO extends PolicyDTO {
+  String name;
+  String monitorId;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyDTO.java
@@ -17,8 +17,10 @@
 package com.rackspace.salus.policy.manage.web.model;
 
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 public class MonitorPolicyDTO extends PolicyDTO {
   String name;
   String monitorId;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/PolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/PolicyDTO.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.rackspace.salus.policy.manage.model.Scope;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public abstract class PolicyDTO {
+  UUID id;
+  Scope scope;
+  String subscope;
+  String createdTimestamp;
+  String updatedTimestamp;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataCU.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataCU.java
@@ -14,16 +14,14 @@
  * limitations under the License.
  */
 
-package com.rackspace.salus.policy.manage.model;
+package com.rackspace.salus.policy.manage.web.model;
 
-public enum TenantMetadataKeys {
-  ACCOUNT_TYPE("AccountType");
+import java.util.Map;
+import lombok.Data;
 
-  private final String key;
+@Data
+public class TenantMetadataCU {
+  String accountType;
+  Map<String,String> metadata;
 
-  TenantMetadataKeys(String key) { this.key = key; }
-
-  public String getKey() {
-    return this.key;
-  }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.telemetry.model.View;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class TenantMetadataDTO {
+  UUID id;
+
+  @JsonView(View.Admin.class)
+  String tenantId;
+
+  Map<String,String> metadata;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
@@ -29,6 +29,8 @@ public class TenantMetadataDTO {
   @JsonView(View.Admin.class)
   String tenantId;
 
+  String accountType;
+
   Map<String,String> metadata;
 
   String createdTimestamp;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
@@ -30,4 +30,7 @@ public class TenantMetadataDTO {
   String tenantId;
 
   Map<String,String> metadata;
+
+  String createdTimestamp;
+  String updatedTimestamp;
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,25 @@
+server:
+  port: 8091
+salus:
+  services:
+    resourceManagementUrl: http://localhost:8085
+    monitorManagementUrl: http://localhost:8089
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    database-platform: org.hibernate.dialect.MySQL5Dialect
+    properties:
+      hibernate:
+        generate_statistics: false
+    show-sql: false
+  datasource:
+    username: dev
+    password: pass
+    url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    platform: mysql
+logging:
+  level:
+    com.rackspace.salus: debug
+    web: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+salus:
+  environment: local
+management.endpoints.web.exposure.include: "health,jolokia,metrics"
+spring:
+  application:
+    name: salus-policy-management
+  kafka:
+    producer:
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    consumer:
+      group-id: ${spring.application.name}-${salus.environment}
+      auto-offset-reset: latest
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring:
+          json:
+            trusted:
+              packages: com.rackspace.salus.telemetry.messaging
+  jackson:
+    mapper:
+      default-view-inclusion: true

--- a/src/test/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicyTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/model/validator/ValidPolicyTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.model.validator;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+public class ValidPolicyTest {
+
+  private LocalValidatorFactoryBean validatorFactoryBean;
+
+  @Before
+  public void setup() {
+    validatorFactoryBean = new LocalValidatorFactoryBean();
+    validatorFactoryBean.afterPropertiesSet();
+  }
+
+  @Test
+  public void testValidGlobal() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.GLOBAL)
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    final Set<ConstraintViolation<MonitorPolicyCreate>> errors = validatorFactoryBean.validate(policyCreate);
+
+    assertThat(errors, hasSize(0));
+  }
+
+  @Test
+  public void testInvalidGlobal() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.GLOBAL)
+        .setSubscope("Subscope is not allowed for global scoped policies")
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    final Set<ConstraintViolation<MonitorPolicyCreate>> errors = validatorFactoryBean.validate(policyCreate);
+
+    assertThat(errors, hasSize(1));
+    final ConstraintViolation<MonitorPolicyCreate> violation = errors.iterator().next();
+    assertThat(violation.getMessage(),
+        equalTo("subscope must be set for any non-global policy but not for global policies"));
+  }
+
+  @Test
+  public void testValidAccountType() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.ACCOUNT_TYPE)
+        .setSubscope("Subscope is required")
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    final Set<ConstraintViolation<MonitorPolicyCreate>> errors = validatorFactoryBean.validate(policyCreate);
+
+    assertThat(errors, hasSize(0));
+  }
+
+  @Test
+  public void testInvalidAccountType() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.ACCOUNT_TYPE)
+        .setSubscope("")
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    final Set<ConstraintViolation<MonitorPolicyCreate>> errors = validatorFactoryBean.validate(policyCreate);
+
+    assertThat(errors, hasSize(1));
+    final ConstraintViolation<MonitorPolicyCreate> violation = errors.iterator().next();
+    assertThat(violation.getMessage(),
+        equalTo("subscope must be set for any non-global policy but not for global policies"));
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/PolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/PolicyManagementTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.monitor_management.web.client.MonitorApi;
+import com.rackspace.salus.policy.manage.entities.MonitorPolicy;
+import com.rackspace.salus.policy.manage.entities.Policy;
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.repositories.MonitorPolicyRepository;
+import com.rackspace.salus.policy.manage.repositories.PolicyRepository;
+import com.rackspace.salus.policy.manage.repositories.TenantMetadataRepository;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.resource_management.web.client.ResourceApi;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@Import({PolicyManagement.class})
+public class PolicyManagementTest {
+
+  @MockBean
+  PolicyEventProducer policyEventProducer;
+
+  @MockBean
+  ResourceApi resourceApi;
+
+  @MockBean
+  MonitorApi monitorApi;
+
+  @Autowired
+  PolicyManagement policyManagement;
+
+  @Autowired
+  PolicyRepository policyRepository;
+
+  @Autowired
+  MonitorPolicyRepository monitorPolicyRepository;
+
+  @Autowired
+  TenantMetadataRepository tenantMetadataRepository;
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  private MonitorPolicy defaultMonitorPolicy;
+
+  @Before
+  public void setup() {
+    Policy policy = new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setSubscope(RandomStringUtils.randomAlphabetic(10))
+        .setScope(Scope.ACCOUNT_TYPE);
+
+    defaultMonitorPolicy = (MonitorPolicy) policyRepository.save(policy);
+  }
+
+  @Test
+  public void testGetMonitorPolicy() {
+    Optional<Policy> p = policyManagement.getPolicy(defaultMonitorPolicy.getId());
+
+    assertTrue(p.isPresent());
+    assertTrue(p.get() instanceof MonitorPolicy);
+
+    MonitorPolicy mp = (MonitorPolicy) p.get();
+    assertThat(mp.getId(), notNullValue());
+    assertThat(mp.getScope(), isOneOf(Scope.values()));
+    assertThat(mp.getScope(), equalTo(defaultMonitorPolicy.getScope()));
+    assertThat(mp.getSubscope(), equalTo(defaultMonitorPolicy.getSubscope()));
+    assertThat(mp.getName(), equalTo(defaultMonitorPolicy.getName()));
+    assertThat(mp.getMonitorId(), equalTo(defaultMonitorPolicy.getMonitorId()));
+  }
+
+  @Test
+  public void testCreateMonitorPolicy() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.ACCOUNT_TYPE)
+        .setSubscope(RandomStringUtils.randomAlphabetic(10))
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    Policy policy = policyManagement.createMonitorPolicy(policyCreate);
+    assertTrue(policy instanceof MonitorPolicy);
+
+    assertThat(policy.getId(), notNullValue());
+    assertThat(policy.getScope(), equalTo(policyCreate.getScope()));
+    assertThat(policy.getSubscope(), equalTo(policyCreate.getSubscope()));
+    assertThat(((MonitorPolicy)policy).getName(), equalTo(policyCreate.getName()));
+    assertThat(((MonitorPolicy)policy).getMonitorId(), equalTo(policyCreate.getMonitorId()));
+  }
+
+  @Test
+  public void testCreateMonitorPolicy_duplicatePolicy() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(defaultMonitorPolicy.getScope())
+        .setSubscope(defaultMonitorPolicy.getSubscope())
+        .setName(defaultMonitorPolicy.getName())
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+    assertThatThrownBy(() -> policyManagement.createMonitorPolicy(policyCreate))
+      .isInstanceOf(AlreadyExistsException.class)
+      .hasMessage(
+          String.format("Policy already exists with scope:subscope:name of %s:%s:%s",
+              policyCreate.getScope(), policyCreate.getSubscope(), policyCreate.getName())
+      );
+  }
+
+  @Test
+  @Ignore
+  public void testCreateMonitorPolicy_monitorDoesntExist() {
+    MonitorPolicyCreate policyCreate = new MonitorPolicyCreate()
+        .setScope(Scope.TENANT)
+        .setSubscope(RandomStringUtils.randomAlphabetic(10))
+        .setName(RandomStringUtils.randomAlphabetic(10))
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10));
+
+//    when(monitorApi.getPolicyMonitorById(anyString()))
+//        .thenReturn(false);
+
+    assertThatThrownBy(() -> policyManagement.createMonitorPolicy(policyCreate))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            String.format("Invalid monitor id provided: %s",
+                policyCreate.getMonitorId())
+        );
+  }
+
+  /**
+   * This test saves numerous policies to the database while also adding certain ones to
+   * the `expected` list.  This list is populated with those policies that we would expect
+   * to be effective for the particular test tenant and account type.
+   */
+  @Test
+  public void testGetEffectiveMonitorPoliciesForTenant() {
+    String tenantId = RandomStringUtils.randomNumeric(5);
+    String testAccountType = "TestAccountType";
+
+    tenantMetadataRepository.save(new TenantMetadata()
+        .setTenantId(tenantId)
+        .setAccountType(testAccountType)
+        .setMetadata(Collections.emptyMap()));
+
+    List<Policy> expected = new ArrayList<>();
+
+    // Create a global policy that will not be overridden
+    expected.add(policyRepository.save(new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName("OnlyGlobal")
+        .setScope(Scope.GLOBAL)));
+
+    // Create global policy that will be overridden
+    policyRepository.save(
+        new MonitorPolicy()
+            .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+            .setName("OverriddenByAccountType")
+            .setScope(Scope.GLOBAL)
+    );
+
+    // Create AccountType policy that will override global
+    expected.add(policyRepository.save(new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName("OverriddenByAccountType")
+        .setSubscope(testAccountType)
+        .setScope(Scope.ACCOUNT_TYPE)));
+
+    // Create AccountType policy that will be overridden by tenant
+    policyRepository.save(
+        new MonitorPolicy()
+            .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+            .setName("OverriddenByTenant")
+            .setSubscope(testAccountType)
+            .setScope(Scope.ACCOUNT_TYPE)
+    );
+
+    // Create AccountType policy that will not be overridden
+    expected.add(policyRepository.save(new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName("UniqueAccountPolicy")
+        .setSubscope(testAccountType)
+        .setScope(Scope.ACCOUNT_TYPE)));
+
+    // Create AccountType policy that is irrelevant to our test tenant.
+    policyRepository.save(
+        new MonitorPolicy()
+            .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+            .setName("IrrelevantAccountType")
+            .setSubscope("IrrelevantTenantType")
+            .setScope(Scope.ACCOUNT_TYPE)
+    );
+
+    // Create Tenant policy that will override AccountType
+    expected.add(policyRepository.save(new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName("OverriddenByTenant")
+        .setSubscope(tenantId)
+        .setScope(Scope.TENANT)));
+
+    // Create Tenant policy that will not be overridden
+    expected.add(policyRepository.save(new MonitorPolicy()
+        .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+        .setName("UniqueTenantPolicy")
+        .setSubscope(tenantId)
+        .setScope(Scope.TENANT)));
+
+    // Create Tenant policy that is irrelevant to our test tenant.
+    policyRepository.save(
+        new MonitorPolicy()
+            .setMonitorId(RandomStringUtils.randomAlphabetic(10))
+            .setName("IrrelevantTenant")
+            .setSubscope(RandomStringUtils.randomAlphabetic(10))
+            .setScope(Scope.TENANT)
+    );
+
+    List<Policy> effectivePolicies = policyManagement.getEffectiveMonitorPoliciesForTenant(tenantId);
+
+    assertThat(effectivePolicies, hasSize(5));
+    assertThat(effectivePolicies, containsInAnyOrder(expected.toArray()));
+  }
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
@@ -1,0 +1,126 @@
+/*
+ *
+ *  * Copyright 2019 Rackspace US, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import com.rackspace.salus.policy.manage.repositories.TenantMetadataRepository;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@Import({TenantManagement.class})
+public class TenantManagementTest {
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Autowired
+  TenantManagement tenantManagement;
+
+  @Autowired
+  TenantMetadataRepository tenantMetadataRepository;
+
+  private TenantMetadata defaultMetadata;
+
+  @Before
+  public void setup() {
+    defaultMetadata = tenantMetadataRepository.save(podamFactory.manufacturePojo(TenantMetadata.class));
+  }
+
+  @Test
+  public void testGetMetadata() {
+    TenantMetadata original = tenantMetadataRepository.save(podamFactory.manufacturePojo(TenantMetadata.class));
+    tenantManagement.getMetadata(original.getTenantId());
+    Optional<TenantMetadata> metadata = tenantManagement.getMetadata(original.getTenantId());
+    assertTrue(metadata.isPresent());
+    assertThat(metadata.get(), equalTo(original));
+  }
+
+  @Test
+  public void testGetAccountTypeByTenant() {
+    String accountType = tenantManagement.getAccountTypeByTenant(defaultMetadata.getTenantId());
+    assertThat(accountType, notNullValue());
+    assertThat(accountType, equalTo(defaultMetadata.getAccountType()));
+  }
+
+  @Test
+  public void testGetAccountTypeByTenant_accountDoesntExist() {
+    String accountType = tenantManagement.getAccountTypeByTenant(RandomStringUtils.randomAlphabetic(10));
+    assertThat(accountType, nullValue());
+  }
+
+  @Test
+  public void testCreateTenantMetadata() {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    TenantMetadataCU create = podamFactory.manufacturePojo(TenantMetadataCU.class);
+
+    TenantMetadata metadata = tenantManagement.upsertTenantMetadata(tenantId, create);
+    assertThat(metadata, notNullValue());
+    assertThat(metadata.getId(), notNullValue());
+    assertThat(metadata.getTenantId(), equalTo(tenantId));
+    assertThat(metadata.getAccountType(), equalTo(create.getAccountType()));
+    assertThat(metadata.getMetadata(), equalTo(create.getMetadata()));
+  }
+
+  @Test
+  public void testUpdateTenantMetadata() {
+    TenantMetadata original = tenantMetadataRepository.save(podamFactory.manufacturePojo(TenantMetadata.class));
+
+    Map<String, String> newMetadata = new HashMap<>(original.getMetadata());
+    newMetadata.put("new", "value");
+
+    TenantMetadataCU update = new TenantMetadataCU()
+        .setAccountType("updated AccountType")
+        .setMetadata(newMetadata);
+
+    TenantMetadata metadata = tenantManagement.upsertTenantMetadata(original.getTenantId(), update);
+    assertThat(metadata, notNullValue());
+    assertThat(metadata.getId(), equalTo(original.getId()));
+    assertThat(metadata.getTenantId(), equalTo(original.getTenantId()));
+    assertThat(metadata.getAccountType(), equalTo(update.getAccountType()));
+    assertThat(metadata.getMetadata(), equalTo(update.getMetadata()));
+  }
+
+  @Test
+  public void testRemoveTenantMetadata() {
+    TenantMetadata original = tenantMetadataRepository.save(podamFactory.manufacturePojo(TenantMetadata.class));
+    tenantManagement.removeTenantMetadata(original.getTenantId());
+    Optional<TenantMetadata> metadata = tenantManagement.getMetadata(original.getTenantId());
+    assertTrue(metadata.isEmpty());
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
@@ -64,7 +64,6 @@ public class TenantManagementTest {
   @Test
   public void testGetMetadata() {
     TenantMetadata original = tenantMetadataRepository.save(podamFactory.manufacturePojo(TenantMetadata.class));
-    tenantManagement.getMetadata(original.getTenantId());
     Optional<TenantMetadata> metadata = tenantManagement.getMetadata(original.getTenantId());
     assertTrue(metadata.isPresent());
     assertThat(metadata.get(), equalTo(original));

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiControllerTest.java
@@ -159,9 +159,7 @@ public class PolicyApiControllerTest {
         "/api/admin/policy/monitors/{uuid}", id)
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
-        .andExpect(status().isNoContent())
-        .andExpect(content()
-            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON));
+        .andExpect(status().isNoContent());
 
     verify(policyManagement).removePolicy(id);
     verifyNoMoreInteractions(policyManagement);

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/PolicyApiControllerTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import static com.rackspace.salus.test.JsonTestUtils.readContent;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.rackspace.salus.policy.manage.entities.MonitorPolicy;
+import com.rackspace.salus.policy.manage.entities.Policy;
+import com.rackspace.salus.policy.manage.model.Scope;
+import com.rackspace.salus.policy.manage.services.PolicyManagement;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(PolicyApiController.class)
+public class PolicyApiControllerTest {
+  @Autowired
+  MockMvc mvc;
+
+  @MockBean
+  PolicyManagement policyManagement;
+
+  // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
+  private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
+
+  @Test
+  public void testGetById() throws Exception {
+    Policy policy = new MonitorPolicy()
+        .setMonitorId("1234-5678-0987")
+        .setName("Test Name")
+        .setScope(Scope.GLOBAL)
+        .setId(UUID.fromString("c0f88d34-2833-4ebb-926c-3601795901f9"))
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+
+    when(policyManagement.getPolicy(any()))
+        .thenReturn(Optional.of(policy));
+
+    mvc.perform(get(
+        "/api/admin/policy/monitors/{uuid}", policy.getId())
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("PolicyApiControllerTest/global_policy.json"), true));
+  }
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *  * Copyright 2019 Rackspace US, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import static com.rackspace.salus.test.JsonTestUtils.readContent;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.policy.manage.entities.TenantMetadata;
+import com.rackspace.salus.policy.manage.services.TenantManagement;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import edu.emory.mathcs.backport.java.util.Collections;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+import org.springframework.http.MediaType;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(TenantApiController.class)
+public class TenantApiControllerTest {
+
+  // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
+  private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Autowired
+  MockMvc mvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  TenantManagement tenantManagement;
+
+  @Test
+  public void testGetMetadata() throws Exception {
+    TenantMetadata metadata = new TenantMetadata()
+        .setId(UUID.fromString("09867b47-2da6-4100-9366-8facf499285a"))
+        .setTenantId("MyTenantId")
+        .setAccountType("MyAccountType")
+        .setMetadata(Collections.singletonMap("dummy", "value"))
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+
+    when(tenantManagement.getMetadata(any()))
+        .thenReturn(Optional.of(metadata));
+
+    mvc.perform(get(
+        "/api/public/account/{tenantId}", metadata.getTenantId())
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("TenantApiControllerTest/basic_tenant_metadata.json"), true));
+
+    verify(tenantManagement).getMetadata(metadata.getTenantId());
+    verifyNoMoreInteractions(tenantManagement);
+  }
+
+  @Test
+  public void testUpsertMetadata() throws Exception {
+    TenantMetadata metadata = new TenantMetadata()
+        .setId(UUID.fromString("09867b47-2da6-4100-9366-8facf499285a"))
+        .setTenantId("MyTenantId")
+        .setAccountType("MyAccountType")
+        .setMetadata(Collections.singletonMap("dummy", "value"))
+        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
+        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+
+    when(tenantManagement.upsertTenantMetadata(anyString(), any()))
+        .thenReturn(metadata);
+
+    TenantMetadataCU createOrUpdate = podamFactory.manufacturePojo(TenantMetadataCU.class);
+    mvc.perform(put(
+        "/api/public/account/{tenantId}", metadata.getTenantId())
+        .content(objectMapper.writeValueAsString(createOrUpdate))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("TenantApiControllerTest/basic_tenant_metadata.json"), true));
+
+    verify(tenantManagement).upsertTenantMetadata(metadata.getTenantId(), createOrUpdate);
+    verifyNoMoreInteractions(tenantManagement);
+
+  }
+
+  @Test
+  public void testRemoveMetadata() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    mvc.perform(delete(
+        "/api/public/account/{tenantId}", tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+
+    verify(tenantManagement).removeTenantMetadata(tenantId);
+    verifyNoMoreInteractions(tenantManagement);
+  }
+}

--- a/src/test/resources/PolicyApiControllerTest/global_policy.json
+++ b/src/test/resources/PolicyApiControllerTest/global_policy.json
@@ -1,0 +1,9 @@
+{
+  "id": "c0f88d34-2833-4ebb-926c-3601795901f9",
+  "scope": "GLOBAL",
+  "subscope": null,
+  "name": "Test Name",
+  "monitorId": "1234-5678-0987",
+  "createdTimestamp": "1970-01-02T03:46:40Z",
+  "updatedTimestamp": "1970-01-02T03:46:40Z"
+}

--- a/src/test/resources/TenantApiControllerTest/basic_tenant_metadata.json
+++ b/src/test/resources/TenantApiControllerTest/basic_tenant_metadata.json
@@ -1,0 +1,9 @@
+{
+  "id": "09867b47-2da6-4100-9366-8facf499285a",
+  "accountType": "MyAccountType",
+  "metadata": {
+    "dummy": "value"
+  },
+  "createdTimestamp": "1970-01-02T03:46:40Z",
+  "updatedTimestamp": "1970-01-02T03:46:40Z"
+}


### PR DESCRIPTION
# What

Adds the first implementation of the Policy Management service.

# How

This contains of two main components, `PolicyManagement` and `TenantManagement`.

`TenantManagement` is pretty simple and right now is only really used to store the `AccountType` of a particular tenant, which can be used to determine what Monitor Policies relate to it.

`PolicyManagement` is where all the Monitor Policies are stored.  It creates `PolicyEvent`s whenever a policy is created or deleted (updates are not allowed).

See the design doc for more info.  In future it will reside in https://github.com/racker/salus-docs

## How to test

Run tests

# Why

This will be used to manage default policies and default metadata.

For example, there could be a Global Monitor Policy that causes a Ping monitor to be created for every resource in the system.  That monitor could also be configured to use default metadata values such as `${rackspace.monitoring_zones}`.  Those defaults would reside in Policy Management, and if they were ever updated all bound monitors using it would be updated.

# TODO

Next step is updating Monitor Management to handle the policy events.

Also need to update insomnia.