### PR TITLE
Only send policy events for relevant accounts

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -27,6 +27,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Index;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
@@ -38,7 +40,12 @@ import org.hibernate.validator.constraints.NotBlank;
 
 @Entity
 @Table(name = "tenant_metadata", indexes = {
-    @Index(name = "by_tenant", columnList = "tenant_id")
+    @Index(name = "by_tenant", columnList = "tenant_id"),
+    @Index(name = "by_account_type", columnList = "account_type")
+})
+@NamedQueries({
+    @NamedQuery(name = "Tenant.getByAccountType",
+        query = "select distinct t.tenantId from TenantMetadata t where t.accountType = :accountType")
 })
 @TypeDef(name = "json", typeClass = JsonStringType.class)
 @Data

--- a/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/entities/TenantMetadata.java
@@ -44,7 +44,7 @@ import org.hibernate.validator.constraints.NotBlank;
     @Index(name = "by_account_type", columnList = "account_type")
 })
 @NamedQueries({
-    @NamedQuery(name = "Tenant.getByAccountType",
+    @NamedQuery(name = "TenantMetadata.getByAccountType",
         query = "select distinct t.tenantId from TenantMetadata t where t.accountType = :accountType")
 })
 @TypeDef(name = "json", typeClass = JsonStringType.class)

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -27,7 +27,6 @@ import com.rackspace.salus.resource_management.web.client.ResourceApi;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -37,9 +36,11 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.persistence.EntityManager;
 import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class PolicyManagement {
 
@@ -93,6 +94,7 @@ public class PolicyManagement {
         .setScope(create.getScope());
 
     policyRepository.save(policy);
+    log.info("Stored new policy {}", policy);
     sendMonitorPolicyEvents((MonitorPolicy) policy);
 
     return policy;
@@ -162,6 +164,7 @@ public class PolicyManagement {
             String.format("No policy found with id %s", id)));
 
     policyRepository.deleteById(id);
+    log.info("Removed policy {}", policy);
     sendMonitorPolicyEvents((MonitorPolicy) policy);
   }
 
@@ -190,6 +193,7 @@ public class PolicyManagement {
    * @param policy The MonitorPolicy to distribute out to all tenants.
    */
   private void sendMonitorPolicyEvents(MonitorPolicy policy) {
+    log.info("Sending monitor policy events for {}", policy);
     List<String> tenantIds;
 
     switch(policy.getScope()) {


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-556

# What

Only send Policy Events to Kafka for accounts we know could be relevant.

# Why

Rather than sending events out for all accounts every time, we can easily determine what subset of accounts are relevant for any Account Type or Tenant based policy.

This should greatly reduce the amount of work Monitor Mgmt has to do for those smaller changes.

# TODO

Once we switch this over to use the shared db, it'll simplify the existing request to get all distinct tenants for global changes.