### PR TITLE
Add management of Metadata Policies

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/config/ServicesProperties.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/config/ServicesProperties.java
@@ -18,7 +18,6 @@ package com.rackspace.salus.policy.manage.config;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.stereotype.Component;
 
 @ConfigurationProperties("salus.services")

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -16,11 +16,13 @@
 
 package com.rackspace.salus.policy.manage.services;
 
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCU;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.repositories.MetadataPolicyRepository;
 import java.util.Comparator;
 import java.util.List;
@@ -28,8 +30,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import javax.persistence.EntityManager;
 import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -38,14 +43,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class MetadataPolicyManagement {
 
+  private final EntityManager entityManager;
   private final MetadataPolicyRepository metadataPolicyRepository;
   private final PolicyEventProducer policyEventProducer;
   private final PolicyManagement policyManagement;
 
   public MetadataPolicyManagement(
+      EntityManager entityManager,
       MetadataPolicyRepository metadataPolicyRepository,
       PolicyEventProducer policyEventProducer,
       PolicyManagement policyManagement) {
+    this.entityManager = entityManager;
     this.metadataPolicyRepository = metadataPolicyRepository;
     this.policyEventProducer = policyEventProducer;
     this.policyManagement = policyManagement;
@@ -70,36 +78,6 @@ public class MetadataPolicyManagement {
   }
 
   /**
-   * Gets all the metadata policies relevant to a tenant.
-   *
-   * Filters the list of all policies down to those that fall into the correct scope/subscope for
-   * the provided tenant.
-   *
-   * @param tenantId The tenantId to retrieve policies for.
-   * @return The list of effective metadata policies that should be applied to the tenant's resources.
-   */
-  public List<MetadataPolicy> getEffectiveMetadataPoliciesForTenant(String tenantId) {
-    return
-        // Create a stream from all metadata policies
-        StreamSupport.stream(metadataPolicyRepository.findAll().spliterator(), false)
-            // Filter the stream for only those policies relevant to this tenant
-            .filter(policy -> policyManagement.isPolicyApplicable(policy, tenantId))
-            // Get one policy for each policy name
-            .collect(
-                // First group the policies by name
-                Collectors.groupingBy(MetadataPolicy::getKey,
-                    // then filter each group by only retrieving the one with the highest priority
-                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
-            )
-            // Now we have a map of policy name -> (optional) metadata policy
-            .values().stream()
-            // Filter out any of the optional objects that do not contain anything
-            .filter(Optional::isPresent).map(Optional::get)
-            // Finally convert to a list of the relevant metadata policies
-            .collect(Collectors.toList());
-  }
-
-  /**
    * Creates a new policy in the database.
    *
    * @param create The details of the policy to create.
@@ -107,11 +85,12 @@ public class MetadataPolicyManagement {
    * @throws AlreadyExistsException if an equivalent policy already exists.
    * @throws IllegalArgumentException if the parameters provided are not valid.
    */
-  public MetadataPolicy createMetadataPolicy(@Valid MetadataPolicyCU create)
+  public MetadataPolicy createMetadataPolicy(@Valid MetadataPolicyCreate create)
       throws AlreadyExistsException, IllegalArgumentException {
     if (exists(create)) {
-      throw new AlreadyExistsException(String.format("Policy already exists with scope:subscope:key of %s:%s:%s",
-          create.getScope(), create.getSubscope(), create.getKey()));
+      throw new AlreadyExistsException(String.format("Policy already exists with "
+              + "scope:subscope:type:key of %s:%s:%s:%s",
+          create.getScope(), create.getSubscope(), create.getMonitorType(), create.getKey()));
     }
     MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
         .setValue(create.getValue())
@@ -123,6 +102,28 @@ public class MetadataPolicyManagement {
 
     metadataPolicyRepository.save(policy);
     log.info("Stored new policy {}", policy);
+    sendMetadataPolicyEvents(policy);
+
+    return policy;
+  }
+
+  public MetadataPolicy updateMetadataPolicy(UUID id, @Valid MetadataPolicyUpdate update) {
+    MetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
+        new NotFoundException(String.format("No policy metadata found for %s", id)));
+
+    log.info("Updating policy metadata={} with new values={}", id, update);
+
+    PropertyMapper map = PropertyMapper.get();
+    map.from(update.getValueType())
+        .whenNonNull()
+        .to(policy::setValueType);
+    map.from(update.getValue())
+        .whenNonNull()
+        .to(policy::setValue);
+
+    policy = metadataPolicyRepository.save(policy);
+    log.info("Policy metadata={} stored with new values={}", id, policy);
+
     sendMetadataPolicyEvents(policy);
 
     return policy;
@@ -149,7 +150,7 @@ public class MetadataPolicyManagement {
   private void sendMetadataPolicyEvents(MetadataPolicy policy) {
     log.info("Sending metadata policy events for {}", policy);
 
-    List<String> tenantIds = policyManagement.getTenantsForPolicy(policy);
+    List<String> tenantIds = getTenantsForMetadataPolicy(policy);
 
     tenantIds.stream()
         .map(tenantId -> new MetadataPolicyEvent()
@@ -159,13 +160,77 @@ public class MetadataPolicyManagement {
   }
 
   /**
+   * Gets all the metadata policies relevant to a tenant.
+   *
+   * Filters the list of all policies down to those that fall into the correct scope/subscope for
+   * the provided tenant.
+   *
+   * @param tenantId The tenantId to retrieve policies for.
+   * @return The list of effective metadata policies that should be applied to the tenant's resources.
+   */
+  public List<MetadataPolicy> getEffectiveMetadataPoliciesForTenant(String tenantId) {
+    return
+        // Create a stream from all metadata policies
+        StreamSupport.stream(metadataPolicyRepository.findAll().spliterator(), false)
+            // Filter the stream for only those policies relevant to this tenant
+            .filter(policy -> policyManagement.isPolicyApplicable(policy, tenantId))
+            // Get one policy for each policy name
+            .collect(
+                // First group the policies by monitor type and key
+                Collectors.groupingBy(policy -> Pair.of(policy.getMonitorType(), policy.getKey()),
+                    // then filter each group by only retrieving the one with the highest priority
+                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
+            )
+            // Now we have a map of policy name -> (optional) metadata policy
+            .values().stream()
+            // Filter out any of the optional objects that do not contain anything
+            .filter(Optional::isPresent).map(Optional::get)
+            // Finally convert to a list of the relevant metadata policies
+            .collect(Collectors.toList());
+  }
+
+  /**
    * Tests whether an equivalent policy already exists.
    *
    * @param policy The scope, subscope, and name of this policy will be looked up.
    * @return True if a policy already exists for these keys, false otherwise.
    */
-  private boolean exists(MetadataPolicyCU policy) {
-    return metadataPolicyRepository.existsByScopeAndSubscopeAndKey(
-        policy.getScope(), policy.getSubscope(), policy.getKey());
+  private boolean exists(MetadataPolicyCreate policy) {
+    return metadataPolicyRepository.existsByScopeAndSubscopeAndMonitorTypeAndKey(
+        policy.getScope(), policy.getSubscope(), policy.getMonitorType(), policy.getKey());
+  }
+
+  /**
+   * Send events for all accounts that the policy may be relevant for.
+   *
+   * In the end, the consumer of these events will ultimately be responsible for determining
+   * if the field is relevant or not.
+   *
+   * This method potentially returns a superset of those that are relevant.
+   *
+   * @param policy The policy to send events for.
+   * @return A list of tenants that may be relevant to the policy.
+   */
+  List<String> getTenantsForMetadataPolicy(MetadataPolicy policy) {
+    List<String> tenantsUsingPolicyKey = entityManager
+        .createNamedQuery("Monitor.getTenantsUsingTemplateVariable", String.class)
+        .setParameter("variable", policy.getKey())
+        .getResultList();
+    if (policy.getScope().equals(PolicyScope.GLOBAL)) {
+      return tenantsUsingPolicyKey;
+    } else {
+      // Rather than sending events for all accounts, we can limit it based on those in this scope.
+      List<String> tenantsInPolicyType = policyManagement.getTenantsForPolicy(policy);
+      return tenantsUsingPolicyKey
+          .stream()
+          .distinct()
+          .filter(tenantsInPolicyType::contains)
+          .collect(Collectors.toList());
+    }
+
+    // Does this logic also handle updating bound policy monitors???
+
+    //testCreateMetadataPolicy update this test to have a monitor stored already.
+    // or mock the monitor sql response
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -201,7 +201,7 @@ public class MetadataPolicyManagement {
   }
 
   /**
-   * Send events for all accounts that the policy may be relevant for.
+   * Get events for all accounts that the policy may be relevant for.
    *
    * In the end, the consumer of these events will ultimately be responsible for determining
    * if the field is relevant or not.

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -16,25 +16,11 @@
 
 package com.rackspace.salus.policy.manage.services;
 
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
-import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
-import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
-import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.repositories.MetadataPolicyRepository;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-import javax.persistence.EntityManager;
-import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
-import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -43,20 +29,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class MetadataPolicyManagement {
 
-  private final EntityManager entityManager;
   private final MetadataPolicyRepository metadataPolicyRepository;
-  private final PolicyEventProducer policyEventProducer;
-  private final PolicyManagement policyManagement;
 
   public MetadataPolicyManagement(
-      EntityManager entityManager,
-      MetadataPolicyRepository metadataPolicyRepository,
-      PolicyEventProducer policyEventProducer,
-      PolicyManagement policyManagement) {
-    this.entityManager = entityManager;
+      MetadataPolicyRepository metadataPolicyRepository) {
     this.metadataPolicyRepository = metadataPolicyRepository;
-    this.policyEventProducer = policyEventProducer;
-    this.policyManagement = policyManagement;
   }
 
   /**
@@ -75,157 +52,5 @@ public class MetadataPolicyManagement {
    */
   public Page<MetadataPolicy> getAllMetadataPolicies(Pageable page) {
     return metadataPolicyRepository.findAll(page);
-  }
-
-  /**
-   * Creates a new policy in the database.
-   *
-   * @param create The details of the policy to create.
-   * @return The full details of the saved policy.
-   * @throws AlreadyExistsException if an equivalent policy already exists.
-   * @throws IllegalArgumentException if the parameters provided are not valid.
-   */
-  public MetadataPolicy createMetadataPolicy(@Valid MetadataPolicyCreate create)
-      throws AlreadyExistsException, IllegalArgumentException {
-    if (exists(create)) {
-      throw new AlreadyExistsException(String.format("Policy already exists with "
-              + "scope:subscope:type:key of %s:%s:%s:%s",
-          create.getScope(), create.getSubscope(), create.getMonitorType(), create.getKey()));
-    }
-    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
-        .setValue(create.getValue())
-        .setKey(create.getKey())
-        .setValueType(create.getValueType())
-        .setMonitorType(create.getMonitorType())
-        .setSubscope(create.getSubscope())
-        .setScope(create.getScope());
-
-    metadataPolicyRepository.save(policy);
-    log.info("Stored new policy {}", policy);
-    sendMetadataPolicyEvents(policy);
-
-    return policy;
-  }
-
-  public MetadataPolicy updateMetadataPolicy(UUID id, @Valid MetadataPolicyUpdate update) {
-    MetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
-        new NotFoundException(String.format("No policy metadata found for %s", id)));
-
-    log.info("Updating policy metadata={} with new values={}", id, update);
-
-    PropertyMapper map = PropertyMapper.get();
-    map.from(update.getValueType())
-        .whenNonNull()
-        .to(policy::setValueType);
-    map.from(update.getValue())
-        .whenNonNull()
-        .to(policy::setValue);
-
-    policy = metadataPolicyRepository.save(policy);
-    log.info("Policy metadata={} stored with new values={}", id, policy);
-
-    sendMetadataPolicyEvents(policy);
-
-    return policy;
-  }
-
-  /**
-   * Removes the metadata policy from the database and sends policy events for each tenant.
-   * @param id The id of the policy to remove.
-   */
-  public void removeMetadataPolicy(UUID id) {
-    MetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
-        new NotFoundException(
-            String.format("No policy found with id %s", id)));
-
-    metadataPolicyRepository.deleteById(id);
-    log.info("Removed policy {}", policy);
-    sendMetadataPolicyEvents(policy);
-  }
-
-  /**
-   * Sends metadata policy events for all potentially relevant tenants.
-   * @param policy The MetadataPolicy to distribute out to all tenants.
-   */
-  private void sendMetadataPolicyEvents(MetadataPolicy policy) {
-    log.info("Sending metadata policy events for {}", policy);
-
-    List<String> tenantIds = getTenantsForMetadataPolicy(policy);
-
-    tenantIds.stream()
-        .map(tenantId -> new MetadataPolicyEvent()
-            .setPolicyId(policy.getId())
-            .setTenantId(tenantId))
-        .forEach(policyEventProducer::sendPolicyEvent);
-  }
-
-  /**
-   * Gets all the metadata policies relevant to a tenant.
-   *
-   * Filters the list of all policies down to those that fall into the correct scope/subscope for
-   * the provided tenant.
-   *
-   * @param tenantId The tenantId to retrieve policies for.
-   * @return The list of effective metadata policies that should be applied to the tenant's resources.
-   */
-  public List<MetadataPolicy> getEffectiveMetadataPoliciesForTenant(String tenantId) {
-    return
-        // Create a stream from all metadata policies
-        StreamSupport.stream(metadataPolicyRepository.findAll().spliterator(), false)
-            // Filter the stream for only those policies relevant to this tenant
-            .filter(policy -> policyManagement.isPolicyApplicable(policy, tenantId))
-            // Get one policy for each policy name
-            .collect(
-                // First group the policies by monitor type and key
-                Collectors.groupingBy(policy -> Pair.of(policy.getMonitorType(), policy.getKey()),
-                    // then filter each group by only retrieving the one with the highest priority
-                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
-            )
-            // Now we have a map of policy name -> (optional) metadata policy
-            .values().stream()
-            // Filter out any of the optional objects that do not contain anything
-            .filter(Optional::isPresent).map(Optional::get)
-            // Finally convert to a list of the relevant metadata policies
-            .collect(Collectors.toList());
-  }
-
-  /**
-   * Tests whether an equivalent policy already exists.
-   *
-   * @param policy The scope, subscope, and name of this policy will be looked up.
-   * @return True if a policy already exists for these keys, false otherwise.
-   */
-  private boolean exists(MetadataPolicyCreate policy) {
-    return metadataPolicyRepository.existsByScopeAndSubscopeAndMonitorTypeAndKey(
-        policy.getScope(), policy.getSubscope(), policy.getMonitorType(), policy.getKey());
-  }
-
-  /**
-   * Get a list of tenants that the policy may be relevant for.
-   *
-   * In the end, the consumer of these events will ultimately be responsible for determining
-   * if the field is relevant or not.
-   *
-   * This method potentially returns a superset of those that are relevant.
-   *
-   * @param policy The policy to send events for.
-   * @return A list of tenants that may be relevant to the policy.
-   */
-  List<String> getTenantsForMetadataPolicy(MetadataPolicy policy) {
-    List<String> tenantsUsingPolicyKey = entityManager
-        .createNamedQuery("Monitor.getTenantsUsingTemplateVariable", String.class)
-        .setParameter("variable", policy.getKey())
-        .getResultList();
-    if (policy.getScope().equals(PolicyScope.GLOBAL)) {
-      return tenantsUsingPolicyKey;
-    } else {
-      // Rather than sending events for all accounts, we can limit it based on those in this scope.
-      List<String> tenantsInPolicyType = policyManagement.getTenantsForPolicy(policy);
-      return tenantsUsingPolicyKey
-          .stream()
-          .distinct()
-          .filter(tenantsInPolicyType::contains)
-          .collect(Collectors.toList());
-    }
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -201,7 +201,7 @@ public class MetadataPolicyManagement {
   }
 
   /**
-   * Get events for all accounts that the policy may be relevant for.
+   * Get a list of tenants that the policy may be relevant for.
    *
    * In the end, the consumer of these events will ultimately be responsible for determining
    * if the field is relevant or not.

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCU;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.repositories.MetadataPolicyRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class MetadataPolicyManagement {
+
+  private final MetadataPolicyRepository metadataPolicyRepository;
+  private final PolicyEventProducer policyEventProducer;
+  private final PolicyManagement policyManagement;
+
+  public MetadataPolicyManagement(
+      MetadataPolicyRepository metadataPolicyRepository,
+      PolicyEventProducer policyEventProducer,
+      PolicyManagement policyManagement) {
+    this.metadataPolicyRepository = metadataPolicyRepository;
+    this.policyEventProducer = policyEventProducer;
+    this.policyManagement = policyManagement;
+  }
+
+  /**
+   * Gets the full policy details with the provided id.
+   * @param id The id of the policy to retrieve.
+   * @return The full policy details.
+   */
+  public Optional<MetadataPolicy> getMetadataPolicy(UUID id) {
+    return metadataPolicyRepository.findById(id);
+  }
+
+  /**
+   * Returns all the metadata policies configured.
+   * @param page The slice of results to be returned.
+   * @return A Page of metadata policies.
+   */
+  public Page<MetadataPolicy> getAllMetadataPolicies(Pageable page) {
+    return metadataPolicyRepository.findAll(page);
+  }
+
+  /**
+   * Gets all the metadata policies relevant to a tenant.
+   *
+   * Filters the list of all policies down to those that fall into the correct scope/subscope for
+   * the provided tenant.
+   *
+   * @param tenantId The tenantId to retrieve policies for.
+   * @return The list of effective metadata policies that should be applied to the tenant's resources.
+   */
+  public List<MetadataPolicy> getEffectiveMetadataPoliciesForTenant(String tenantId) {
+    return
+        // Create a stream from all metadata policies
+        StreamSupport.stream(metadataPolicyRepository.findAll().spliterator(), false)
+            // Filter the stream for only those policies relevant to this tenant
+            .filter(policy -> policyManagement.isPolicyApplicable(policy, tenantId))
+            // Get one policy for each policy name
+            .collect(
+                // First group the policies by name
+                Collectors.groupingBy(MetadataPolicy::getKey,
+                    // then filter each group by only retrieving the one with the highest priority
+                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
+            )
+            // Now we have a map of policy name -> (optional) metadata policy
+            .values().stream()
+            // Filter out any of the optional objects that do not contain anything
+            .filter(Optional::isPresent).map(Optional::get)
+            // Finally convert to a list of the relevant metadata policies
+            .collect(Collectors.toList());
+  }
+
+  /**
+   * Creates a new policy in the database.
+   *
+   * @param create The details of the policy to create.
+   * @return The full details of the saved policy.
+   * @throws AlreadyExistsException if an equivalent policy already exists.
+   * @throws IllegalArgumentException if the parameters provided are not valid.
+   */
+  public MetadataPolicy createMetadataPolicy(@Valid MetadataPolicyCU create)
+      throws AlreadyExistsException, IllegalArgumentException {
+    if (exists(create)) {
+      throw new AlreadyExistsException(String.format("Policy already exists with scope:subscope:key of %s:%s:%s",
+          create.getScope(), create.getSubscope(), create.getKey()));
+    }
+    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
+        .setValue(create.getValue())
+        .setKey(create.getKey())
+        .setValueType(create.getValueType())
+        .setMonitorType(create.getMonitorType())
+        .setSubscope(create.getSubscope())
+        .setScope(create.getScope());
+
+    metadataPolicyRepository.save(policy);
+    log.info("Stored new policy {}", policy);
+    sendMetadataPolicyEvents(policy);
+
+    return policy;
+  }
+
+  /**
+   * Removes the metadata policy from the database and sends policy events for each tenant.
+   * @param id The id of the policy to remove.
+   */
+  public void removeMetadataPolicy(UUID id) {
+    MetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
+        new NotFoundException(
+            String.format("No policy found with id %s", id)));
+
+    metadataPolicyRepository.deleteById(id);
+    log.info("Removed policy {}", policy);
+    sendMetadataPolicyEvents(policy);
+  }
+
+  /**
+   * Sends metadata policy events for all potentially relevant tenants.
+   * @param policy The MetadataPolicy to distribute out to all tenants.
+   */
+  private void sendMetadataPolicyEvents(MetadataPolicy policy) {
+    log.info("Sending metadata policy events for {}", policy);
+
+    List<String> tenantIds = policyManagement.getTenantsForPolicy(policy);
+
+    tenantIds.stream()
+        .map(tenantId -> new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId))
+        .forEach(policyEventProducer::sendPolicyEvent);
+  }
+
+  /**
+   * Tests whether an equivalent policy already exists.
+   *
+   * @param policy The scope, subscope, and name of this policy will be looked up.
+   * @return True if a policy already exists for these keys, false otherwise.
+   */
+  private boolean exists(MetadataPolicyCU policy) {
+    return metadataPolicyRepository.existsByScopeAndSubscopeAndKey(
+        policy.getScope(), policy.getSubscope(), policy.getKey());
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagement.java
@@ -227,10 +227,5 @@ public class MetadataPolicyManagement {
           .filter(tenantsInPolicyType::contains)
           .collect(Collectors.toList());
     }
-
-    // Does this logic also handle updating bound policy monitors???
-
-    //testCreateMetadataPolicy update this test to have a monitor stored already.
-    // or mock the monitor sql response
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
+import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.model.TargetClassName;
+import com.rackspace.salus.telemetry.repositories.MonitorMetadataPolicyRepository;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.persistence.EntityManager;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class MonitorMetadataPolicyManagement {
+
+  private final EntityManager entityManager;
+  private final MonitorMetadataPolicyRepository monitorMetadataPolicyRepository;
+  private final PolicyEventProducer policyEventProducer;
+  private final PolicyManagement policyManagement;
+
+  public MonitorMetadataPolicyManagement(
+      EntityManager entityManager,
+      MonitorMetadataPolicyRepository monitorMetadataPolicyRepository,
+      PolicyEventProducer policyEventProducer,
+      PolicyManagement policyManagement) {
+    this.entityManager = entityManager;
+    this.monitorMetadataPolicyRepository = monitorMetadataPolicyRepository;
+    this.policyEventProducer = policyEventProducer;
+    this.policyManagement = policyManagement;
+  }
+
+  /**
+   * Gets the full policy details with the provided id.
+   * @param id The id of the policy to retrieve.
+   * @return The full policy details.
+   */
+  public Optional<MonitorMetadataPolicy> getMetadataPolicy(UUID id) {
+    return monitorMetadataPolicyRepository.findById(id);
+  }
+
+  /**
+   * Returns all the metadata policies configured.
+   * @param page The slice of results to be returned.
+   * @return A Page of metadata policies.
+   */
+  public Page<MonitorMetadataPolicy> getAllMetadataPolicies(Pageable page) {
+    return monitorMetadataPolicyRepository.findAll(page);
+  }
+
+  /**
+   * Creates a new policy in the database.
+   *
+   * @param create The details of the policy to create.
+   * @return The full details of the saved policy.
+   * @throws AlreadyExistsException if an equivalent policy already exists.
+   * @throws IllegalArgumentException if the parameters provided are not valid.
+   */
+  public MonitorMetadataPolicy createMetadataPolicy(@Valid MonitorMetadataPolicyCreate create)
+      throws AlreadyExistsException, IllegalArgumentException {
+    if (exists(create)) {
+      throw new AlreadyExistsException(String.format("Policy already exists with "
+              + "scope:subscope:class:type:key of %s:%s:%s:%s:%s",
+          create.getScope(), create.getSubscope(), create.getTargetClassName(), create.getMonitorType(), create.getKey()));
+    }
+
+    MonitorMetadataPolicy policy;
+
+    switch (create.getTargetClassName()) {
+      case Monitor:
+      case RemotePlugin:
+      case LocalPlugin:
+        policy = (MonitorMetadataPolicy) new MonitorMetadataPolicy()
+            .setMonitorType(create.getMonitorType())
+            .setValue(create.getValue())
+            .setKey(create.getKey())
+            .setValueType(create.getValueType())
+            .setTargetClassName(create.getTargetClassName())
+            .setSubscope(create.getSubscope())
+            .setScope(create.getScope());
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid target class name found");
+    }
+
+    monitorMetadataPolicyRepository.save(policy);
+    log.info("Stored new policy {}", policy);
+    sendMetadataPolicyEvents(policy);
+
+    return policy;
+  }
+
+  public MonitorMetadataPolicy updateMetadataPolicy(UUID id, @Valid MetadataPolicyUpdate update) {
+    MonitorMetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
+        new NotFoundException(String.format("No policy metadata found for %s", id)));
+
+    log.info("Updating policy metadata={} with new values={}", id, update);
+
+    PropertyMapper map = PropertyMapper.get();
+    map.from(update.getValueType())
+        .whenNonNull()
+        .to(policy::setValueType);
+    map.from(update.getValue())
+        .whenNonNull()
+        .to(policy::setValue);
+
+    policy = monitorMetadataPolicyRepository.save(policy);
+    log.info("Policy metadata={} stored with new values={}", id, policy);
+
+    sendMetadataPolicyEvents(policy);
+
+    return policy;
+  }
+
+  /**
+   * Removes the metadata policy from the database and sends policy events for each tenant.
+   * @param id The id of the policy to remove.
+   */
+  public void removeMetadataPolicy(UUID id) {
+    MonitorMetadataPolicy policy = getMetadataPolicy(id).orElseThrow(() ->
+        new NotFoundException(
+            String.format("No policy found with id %s", id)));
+
+    monitorMetadataPolicyRepository.deleteById(id);
+    log.info("Removed policy {}", policy);
+    sendMetadataPolicyEvents(policy);
+  }
+
+  /**
+   * Sends metadata policy events for all potentially relevant tenants.
+   * @param policy The MetadataPolicy to distribute out to all tenants.
+   */
+  private void sendMetadataPolicyEvents(MonitorMetadataPolicy policy) {
+    log.info("Sending metadata policy events for {}", policy);
+
+    List<String> tenantIds = getTenantsForMetadataPolicy(policy);
+
+    tenantIds.stream()
+        .map(tenantId -> new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId))
+        .forEach(policyEventProducer::sendPolicyEvent);
+  }
+
+  /**
+   * Gets all the metadata policies relevant to a tenant.
+   *
+   * Filters the list of all policies down to those that fall into the correct scope/subscope for
+   * the provided tenant.
+   *
+   * @param tenantId The tenantId to retrieve policies for.
+   * @return The list of effective metadata policies that should be applied to the tenant's resources.
+   */
+  public List<MonitorMetadataPolicy> getEffectiveMetadataPoliciesForTenant(String tenantId) {
+    return
+        // Create a stream from all metadata policies
+        StreamSupport.stream(monitorMetadataPolicyRepository.findAll().spliterator(), false)
+            // Filter the stream for only those policies relevant to this tenant
+            .filter(policy -> policyManagement.isPolicyApplicable(policy, tenantId))
+            // Get one policy for each policy name
+            .collect(
+                // First group the policies by monitor type and key
+                Collectors.groupingBy(policy -> Pair.of(policy.getMonitorType(), policy.getKey()),
+                    // then filter each group by only retrieving the one with the highest priority
+                    Collectors.maxBy(Comparator.comparingInt(policy -> policy.getScope().getPriority())))
+            )
+            // Now we have a map of policy name -> (optional) metadata policy
+            .values().stream()
+            // Filter out any of the optional objects that do not contain anything
+            .filter(Optional::isPresent).map(Optional::get)
+            // Finally convert to a list of the relevant metadata policies
+            .collect(Collectors.toList());
+  }
+
+  public Map<String, MonitorMetadataPolicy> getMetadataPoliciesForTenantAndType(String tenantId, TargetClassName className, MonitorType monitorType) {
+    List<MonitorMetadataPolicy> listOfPolicies = getEffectiveMetadataPoliciesForTenant(tenantId);
+
+    Map<String, MonitorMetadataPolicy> policyValuesMap = new HashMap<>();
+    for (MonitorMetadataPolicy policy : listOfPolicies) {
+      // Only use policies that are related to the target class name.
+      if (policy.getTargetClassName().equals(className)) {
+        if (policy.getMonitorType() == null) {
+          // Add any generic monitor policy if it does not already have a specific monitor type value set.
+          policyValuesMap.putIfAbsent(policy.getKey(), policy);
+        } else if (policy.getMonitorType().equals(monitorType)) {
+          // Add any policy for the given monitor type.  Override the previously set generic policy if one was already added.
+          policyValuesMap.put(policy.getKey(), policy);
+        }
+      }
+    }
+    return policyValuesMap;
+  }
+
+  /**
+   * Tests whether an equivalent policy already exists.
+   *
+   * @param policy The scope, subscope, and name of this policy will be looked up.
+   * @return True if a policy already exists for these keys, false otherwise.
+   */
+  private boolean exists(MonitorMetadataPolicyCreate policy) {
+    return monitorMetadataPolicyRepository.existsByScopeAndSubscopeAndTargetClassNameAndMonitorTypeAndKey(
+        policy.getScope(), policy.getSubscope(), policy.getTargetClassName(), policy.getMonitorType(), policy.getKey());
+  }
+
+  /**
+   * Get a list of tenants that the policy may be relevant for.
+   *
+   * In the end, the consumer of these events will ultimately be responsible for determining
+   * if the field is relevant or not.
+   *
+   * This method potentially returns a superset of those that are relevant.
+   *
+   * @param policy The policy to send events for.
+   * @return A list of tenants that may be relevant to the policy.
+   */
+  private List<String> getTenantsForMetadataPolicy(MonitorMetadataPolicy policy) {
+    List<String> tenantsUsingPolicyKey;
+    if (policy.getTargetClassName().equals(TargetClassName.Monitor)) {
+      tenantsUsingPolicyKey = entityManager
+          .createNamedQuery("Monitor.getTenantsUsingPolicyMetadataInMonitor", String.class)
+          .setParameter("metadataKey", policy.getKey())
+          .getResultList();
+    } else {
+      tenantsUsingPolicyKey = entityManager
+          .createNamedQuery("Monitor.getTenantsUsingPolicyMetadataInPlugin", String.class)
+          .setParameter("metadataKey", policy.getKey())
+          .getResultList();
+    }
+    if (policy.getScope().equals(PolicyScope.GLOBAL)) {
+      return tenantsUsingPolicyKey;
+    } else {
+      // Rather than sending events for all accounts, we can limit it based on those in this scope.
+      List<String> tenantsInPolicyType = policyManagement.getTenantsForPolicy(policy);
+      return tenantsUsingPolicyKey
+          .stream()
+          .distinct()
+          .filter(tenantsInPolicyType::contains)
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
@@ -40,21 +40,21 @@ public class PolicyEventProducer {
     this.properties= properties;
   }
 
-  public void sendPolicyEvent(PolicyEvent event) {
+  void sendPolicyEvent(PolicyEvent event) {
     final String topic = properties.getPolicies();
 
     log.debug("Sending policyEvent={} on topic={}", event, topic);
     kafkaTemplate.send(topic, buildMessageKey(event), event);
   }
 
-  public void sendPolicyMonitorUpdateEvent(PolicyMonitorUpdateEvent event) {
+  void sendPolicyMonitorUpdateEvent(PolicyMonitorUpdateEvent event) {
     final String topic = properties.getPolicies();
 
     log.debug("Sending policyMonitorUpdateEvent={} on topic={}", event, topic);
     kafkaTemplate.send(topic, buildMessageKey(event), event);
   }
 
-  public void sendTenantChangeEvent(TenantPolicyChangeEvent event) {
+  void sendTenantChangeEvent(TenantPolicyChangeEvent event) {
     final String topic = properties.getPolicies();
 
     log.debug("Sending tenantChangeEvent={} on topic={}", event, topic);

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -47,7 +47,7 @@ public class PolicyManagement {
 
   List<String> getTenantsForPolicy(Policy policy) {
     List<String> tenantIds;
-    switch(policy.getScope()) {
+    switch (policy.getScope()) {
       case GLOBAL:
         tenantIds = getAllDistinctTenantIds();
         break;

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import com.rackspace.salus.telemetry.entities.Policy;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.repositories.PolicyRepository;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PolicyManagement {
+
+  private final PolicyRepository policyRepository;
+  private final EntityManager entityManager;
+  private final TenantManagement tenantManagement;
+
+  public PolicyManagement(
+      PolicyRepository policyRepository, EntityManager entityManager,
+      TenantManagement tenantManagement) {
+    this.policyRepository = policyRepository;
+    this.entityManager = entityManager;
+    this.tenantManagement = tenantManagement;
+  }
+
+  public Optional<Policy> getPolicyById(UUID id) {
+    return policyRepository.findById(id);
+  }
+
+  List<String> getTenantsForPolicy(Policy policy) {
+    List<String> tenantIds;
+    switch(policy.getScope()) {
+      case GLOBAL:
+        tenantIds = getAllDistinctTenantIds();
+        break;
+      case ACCOUNT_TYPE:
+        tenantIds = getTenantsWithAccountType(policy.getSubscope());
+        break;
+      case TENANT:
+        tenantIds = Collections.singletonList(policy.getSubscope());
+        break;
+      default:
+        tenantIds = Collections.emptyList();
+        break;
+    }
+    return tenantIds;
+  }
+
+  /**
+   * Gets a list of all tenants that have at least one resource.
+   * @return A list of tenant ids.
+   */
+  List<String> getAllDistinctTenantIds() {
+    return entityManager
+        .createNamedQuery("Resource.getAllDistinctTenants", String.class)
+        .getResultList();
+  }
+
+  private List<String> getTenantsWithAccountType(String accountType) {
+    return entityManager
+        .createNamedQuery("TenantMetadata.getByAccountType", String.class)
+        .setParameter("accountType", accountType)
+        .getResultList();
+  }
+
+  /**
+   * Determines whether the given policy is relevant to the tenant.
+   *
+   * @param policy The policy to evaluate.
+   * @param tenantId The tenant to evaluate.
+   * @return True if the policy is relevant, even if it is currently overridden. False otherwise.
+   */
+  boolean isPolicyApplicable(Policy policy, String tenantId) {
+    String accountType = tenantManagement.getAccountTypeByTenant(tenantId);
+
+    return policy.getScope().equals(PolicyScope.GLOBAL) ||
+        (policy.getScope().equals(PolicyScope.ACCOUNT_TYPE) && policy.getSubscope().equals(accountType)) ||
+        (policy.getScope().equals(PolicyScope.TENANT) && policy.getSubscope().equals(tenantId));
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -16,8 +16,13 @@
 
 package com.rackspace.salus.policy.manage.web.client;
 
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -29,4 +34,6 @@ import java.util.UUID;
 public interface PolicyApi {
   List<MonitorPolicyDTO> getEffectiveMonitorPolicies(String tenantId);
   List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId);
+  List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId);
+  Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(String tenantId, TargetClassName className, MonitorType monitorType);
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -16,9 +16,14 @@
 
 package com.rackspace.salus.policy.manage.web.client;
 
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
 import com.rackspace.salus.telemetry.entities.MonitorPolicy;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import org.springframework.core.ParameterizedTypeReference;
@@ -54,7 +59,9 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 public class PolicyApiClient implements PolicyApi {
   private static final ParameterizedTypeReference<List<MonitorPolicyDTO>> LIST_OF_MONITOR_POLICY = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<List<MonitorMetadataPolicyDTO>> LIST_OF_MONITOR_METADATA_POLICY = new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<List<UUID>> LIST_OF_UUID = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<Map<String, MonitorMetadataPolicyDTO>> MAP_OF_MONITOR_POLICY = new ParameterizedTypeReference<>() {};
   private final RestTemplate restTemplate;
 
   public PolicyApiClient(RestTemplate restTemplate) {
@@ -86,6 +93,34 @@ public class PolicyApiClient implements PolicyApi {
         HttpMethod.GET,
         null,
         LIST_OF_UUID
+    ).getBody();
+  }
+
+  public List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}")
+        .build(tenantId)
+        .toString();
+
+    return restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        LIST_OF_MONITOR_METADATA_POLICY
+    ).getBody();
+  }
+
+  public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(String tenantId, TargetClassName className, MonitorType monitorType) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
+        .build(tenantId, className, monitorType)
+        .toString();
+
+    return restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        MAP_OF_MONITOR_POLICY
     ).getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -96,7 +96,7 @@ public class MetadataPolicyApiController {
     return new MetadataPolicyDTO(metadataPolicyManagement.createMetadataPolicy(input));
   }
 
-  @PutMapping("/admin/policy/metadata")
+  @PutMapping("/admin/policy/metadata/{uuid}")
   @ApiOperation(value = "Creates new Metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully Created Metadata Policy")})
   @JsonView(View.Admin.class)

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import com.fasterxml.jackson.annotation.JsonView;
+import com.rackspace.salus.policy.manage.services.MetadataPolicyManagement;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PagedContent;
+import com.rackspace.salus.telemetry.model.View;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api")
+public class MetadataPolicyApiController {
+
+  private MetadataPolicyManagement metadataPolicyManagement;
+
+  @Autowired
+  public MetadataPolicyApiController(
+      MetadataPolicyManagement metadataPolicyManagement) {
+    this.metadataPolicyManagement = metadataPolicyManagement;
+  }
+
+  @GetMapping("/admin/policy/metadata/{uuid}")
+  @ApiOperation(value = "Gets specific Metadata Policy by id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Metadata Policy Retrieved")})
+  @JsonView(View.Admin.class)
+  public MetadataPolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
+    return new MetadataPolicyDTO(
+        metadataPolicyManagement.getMetadataPolicy(uuid).orElseThrow(
+            () -> new NotFoundException(String.format("No policy found with id %s", uuid))));
+  }
+
+  @GetMapping("/admin/policy/metadata/effective/{tenantId}")
+  @ApiOperation(value = "Gets effective Metadata policies by tenant id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
+  @JsonView(View.Admin.class)
+  public List<MetadataPolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
+    return metadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(tenantId)
+        .stream().map(MetadataPolicyDTO::new).collect(Collectors.toList());
+  }
+
+  @GetMapping("/admin/policy/metadata")
+  @ApiOperation(value = "Gets all Metadata policies")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
+  @JsonView(View.Admin.class)
+  public PagedContent<MetadataPolicyDTO> getAllMetadataPolicies(Pageable page) {
+    return PagedContent.fromPage(metadataPolicyManagement.getAllMetadataPolicies(page)
+        .map(MetadataPolicyDTO::new));
+  }
+
+  @PostMapping("/admin/policy/metadata")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates new Metadata Policy")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Metadata Policy")})
+  @JsonView(View.Admin.class)
+  public MetadataPolicyDTO create(@Valid @RequestBody final MetadataPolicyCreate input)
+      throws IllegalArgumentException {
+    return new MetadataPolicyDTO(metadataPolicyManagement.createMetadataPolicy(input));
+  }
+
+  @PutMapping("/admin/policy/metadata")
+  @ApiOperation(value = "Creates new Metadata Policy")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully Created Metadata Policy")})
+  @JsonView(View.Admin.class)
+  public MetadataPolicyDTO create(@PathVariable UUID uuid, @Valid @RequestBody final MetadataPolicyUpdate input)
+      throws IllegalArgumentException {
+    return new MetadataPolicyDTO(metadataPolicyManagement.updateMetadataPolicy(uuid, input));
+  }
+
+  @DeleteMapping("/admin/policy/metadata/{uuid}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiOperation(value = "Deletes specific Metadata Policy")
+  @ApiResponses(value = { @ApiResponse(code = 204, message = "Metadata Policy Deleted")})
+  @JsonView(View.Admin.class)
+  public void delete(@PathVariable UUID uuid) {
+    metadataPolicyManagement.removeMetadataPolicy(uuid);
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -17,17 +17,21 @@
 package com.rackspace.salus.policy.manage.web.controller;
 
 import com.fasterxml.jackson.annotation.JsonView;
-import com.rackspace.salus.policy.manage.services.MetadataPolicyManagement;
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyDTO;
+import com.rackspace.salus.policy.manage.services.MonitorMetadataPolicyManagement;
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import com.rackspace.salus.telemetry.model.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.validation.Valid;
@@ -50,67 +54,82 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api")
 public class MetadataPolicyApiController {
 
-  private MetadataPolicyManagement metadataPolicyManagement;
+  private final MonitorMetadataPolicyManagement monitorMetadataPolicyManagement;
 
   @Autowired
   public MetadataPolicyApiController(
-      MetadataPolicyManagement metadataPolicyManagement) {
-    this.metadataPolicyManagement = metadataPolicyManagement;
+      MonitorMetadataPolicyManagement monitorMetadataPolicyManagement) {
+    this.monitorMetadataPolicyManagement = monitorMetadataPolicyManagement;
   }
 
-  @GetMapping("/admin/policy/metadata/{uuid}")
+  @GetMapping("/admin/policy/metadata/monitor/{uuid}")
   @ApiOperation(value = "Gets specific Metadata Policy by id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Metadata Policy Retrieved")})
   @JsonView(View.Admin.class)
-  public MetadataPolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
-    return new MetadataPolicyDTO(
-        metadataPolicyManagement.getMetadataPolicy(uuid).orElseThrow(
+  public MonitorMetadataPolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
+    return new MonitorMetadataPolicyDTO(
+        monitorMetadataPolicyManagement.getMetadataPolicy(uuid).orElseThrow(
             () -> new NotFoundException(String.format("No policy found with id %s", uuid))));
   }
 
-  @GetMapping("/admin/policy/metadata/effective/{tenantId}")
+  @GetMapping("/admin/policy/metadata/monitor/effective/{tenantId}")
   @ApiOperation(value = "Gets effective Metadata policies by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
   @JsonView(View.Admin.class)
-  public List<MetadataPolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
-    return metadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(tenantId)
-        .stream().map(MetadataPolicyDTO::new).collect(Collectors.toList());
+  public List<MonitorMetadataPolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
+    return monitorMetadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(tenantId)
+        .stream().map(MonitorMetadataPolicyDTO::new).collect(Collectors.toList());
   }
 
-  @GetMapping("/admin/policy/metadata")
-  @ApiOperation(value = "Gets all Metadata policies")
+  @GetMapping("/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
+  @ApiOperation(value = "Gets effective Metadata policies by tenant id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policy values Retrieved")})
+  @JsonView(View.Admin.class)
+  public Map<String, MonitorMetadataPolicyDTO> getPolicyMap(
+      @PathVariable String tenantId, @PathVariable TargetClassName className, @PathVariable MonitorType monitorType) {
+    return monitorMetadataPolicyManagement.getMetadataPoliciesForTenantAndType(tenantId, className, monitorType)
+        .entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            entry -> new MonitorMetadataPolicyDTO(entry.getValue())
+        ));
+  }
+
+  @GetMapping("/admin/policy/metadata/monitor")
+  @ApiOperation(value = "Gets all monitor metadata policies")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
   @JsonView(View.Admin.class)
-  public PagedContent<MetadataPolicyDTO> getAllMetadataPolicies(Pageable page) {
-    return PagedContent.fromPage(metadataPolicyManagement.getAllMetadataPolicies(page)
-        .map(MetadataPolicyDTO::new));
+  public PagedContent<MonitorMetadataPolicyDTO> getAllMetadataPolicies(Pageable page) {
+    return PagedContent.fromPage(monitorMetadataPolicyManagement.getAllMetadataPolicies(page)
+        .map(MonitorMetadataPolicyDTO::new));
   }
 
-  @PostMapping("/admin/policy/metadata")
+  @PostMapping("/admin/policy/metadata/monitor")
   @ResponseStatus(HttpStatus.CREATED)
-  @ApiOperation(value = "Creates new Metadata Policy")
+  @ApiOperation(value = "Creates new monitor metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Metadata Policy")})
   @JsonView(View.Admin.class)
-  public MetadataPolicyDTO create(@Valid @RequestBody final MetadataPolicyCreate input)
+  public MonitorMetadataPolicyDTO createMonitorMetadata(@Valid @RequestBody final MonitorMetadataPolicyCreate input)
       throws IllegalArgumentException {
-    return new MetadataPolicyDTO(metadataPolicyManagement.createMetadataPolicy(input));
+    return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createMetadataPolicy(input));
   }
 
-  @PutMapping("/admin/policy/metadata/{uuid}")
-  @ApiOperation(value = "Creates new Metadata Policy")
+  @PutMapping("/admin/policy/metadata/monitor/{uuid}")
+  @ApiOperation(value = "Updates a monitor metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully Created Metadata Policy")})
   @JsonView(View.Admin.class)
-  public MetadataPolicyDTO create(@PathVariable UUID uuid, @Valid @RequestBody final MetadataPolicyUpdate input)
+  public MonitorMetadataPolicyDTO update(@PathVariable UUID uuid, @Valid @RequestBody final MetadataPolicyUpdate input)
       throws IllegalArgumentException {
-    return new MetadataPolicyDTO(metadataPolicyManagement.updateMetadataPolicy(uuid, input));
+    return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.updateMetadataPolicy(uuid, input));
   }
 
-  @DeleteMapping("/admin/policy/metadata/{uuid}")
+  @DeleteMapping("/admin/policy/metadata/monitor/{uuid}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Metadata Policy Deleted")})
   @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID uuid) {
-    metadataPolicyManagement.removeMetadataPolicy(uuid);
+    monitorMetadataPolicyManagement.removeMetadataPolicy(uuid);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCU.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCU.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import java.io.Serializable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@ValidPolicy
+public class MetadataPolicyCU implements Serializable {
+
+  @NotNull
+  PolicyScope scope;
+
+  String subscope;
+
+  MonitorType monitorType;
+
+  MetadataValueType valueType;
+
+  @NotBlank
+  String key;
+
+  @NotBlank
+  String value;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCreate.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import java.io.Serializable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+@ValidPolicy
+public class MetadataPolicyCreate implements Serializable {
+
+  @NotNull
+  PolicyScope scope;
+
+  String subscope;
+
+  MonitorType monitorType;
+
+  MetadataValueType valueType;
+
+  @NotBlank
+  String key;
+
+  @NotBlank
+  String value;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyCreate.java
@@ -18,8 +18,8 @@ package com.rackspace.salus.policy.manage.web.model;
 
 import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
 import com.rackspace.salus.telemetry.model.MetadataValueType;
-import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -34,7 +34,8 @@ public class MetadataPolicyCreate implements Serializable {
 
   String subscope;
 
-  MonitorType monitorType;
+  @NotNull
+  TargetClassName targetClassName;
 
   MetadataValueType valueType;
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyDTO.java
@@ -18,21 +18,23 @@ package com.rackspace.salus.policy.manage.web.model;
 
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.model.MetadataValueType;
-import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
 public class MetadataPolicyDTO extends PolicyDTO {
-  MonitorType monitorType;
+  TargetClassName targetClassName;
   MetadataValueType valueType;
   String key;
   String value;
 
   public MetadataPolicyDTO(MetadataPolicy policy) {
     super(policy);
-    this.monitorType = policy.getMonitorType();
+    this.targetClassName = policy.getTargetClassName();
     this.valueType = policy.getValueType();
     this.key = policy.getKey();
     this.value = policy.getValue();

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyDTO.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class MetadataPolicyDTO extends PolicyDTO {
+  MonitorType monitorType;
+  MetadataValueType valueType;
+  String key;
+  String value;
+
+  public MetadataPolicyDTO(MetadataPolicy policy) {
+    super(policy);
+    this.monitorType = policy.getMonitorType();
+    this.valueType = policy.getValueType();
+    this.key = policy.getKey();
+    this.value = policy.getValue();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyUpdate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MetadataPolicyUpdate.java
@@ -16,30 +16,15 @@
 
 package com.rackspace.salus.policy.manage.web.model;
 
-import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
 import com.rackspace.salus.telemetry.model.MetadataValueType;
-import com.rackspace.salus.telemetry.model.MonitorType;
-import com.rackspace.salus.telemetry.model.PolicyScope;
 import java.io.Serializable;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
-@ValidPolicy
-public class MetadataPolicyCU implements Serializable {
-
-  @NotNull
-  PolicyScope scope;
-
-  String subscope;
-
-  MonitorType monitorType;
+public class MetadataPolicyUpdate implements Serializable {
 
   MetadataValueType valueType;
-
-  @NotBlank
-  String key;
 
   @NotBlank
   String value;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorMetadataPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorMetadataPolicyCreate.java
@@ -16,22 +16,12 @@
 
 package com.rackspace.salus.policy.manage.web.model;
 
-import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import java.util.UUID;
+import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 @Data
-@EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor
-public class MonitorPolicyDTO extends PolicyDTO {
-  String name;
-  UUID monitorId;
-
-  public MonitorPolicyDTO(MonitorPolicy policy) {
-    super(policy);
-    this.name = policy.getName();
-    this.monitorId = policy.getMonitorId();
-  }
+@ValidPolicy
+public class MonitorMetadataPolicyCreate extends MetadataPolicyCreate {
+  MonitorType monitorType;
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorMetadataPolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorMetadataPolicyDTO.java
@@ -16,8 +16,8 @@
 
 package com.rackspace.salus.policy.manage.web.model;
 
-import com.rackspace.salus.telemetry.entities.MonitorPolicy;
-import java.util.UUID;
+import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -25,13 +25,11 @@ import lombok.NoArgsConstructor;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-public class MonitorPolicyDTO extends PolicyDTO {
-  String name;
-  UUID monitorId;
+public class MonitorMetadataPolicyDTO extends MetadataPolicyDTO {
+  MonitorType monitorType;
 
-  public MonitorPolicyDTO(MonitorPolicy policy) {
+  public MonitorMetadataPolicyDTO(MonitorMetadataPolicy policy) {
     super(policy);
-    this.name = policy.getName();
-    this.monitorId = policy.getMonitorId();
+    this.monitorType = policy.getMonitorType();
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/PolicyDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/PolicyDTO.java
@@ -21,8 +21,10 @@ import com.rackspace.salus.telemetry.model.PolicyScope;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public abstract class PolicyDTO {
   UUID id;
   PolicyScope scope;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
@@ -17,10 +17,11 @@
 package com.rackspace.salus.policy.manage.web.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
+import com.rackspace.salus.telemetry.model.PolicyScope;
 
 public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolicyCreate> {
   @Override
-  protected Enum getScope(MetadataPolicyCreate policy) {
+  protected PolicyScope getScope(MetadataPolicyCreate policy) {
     return policy.getScope();
   }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
@@ -16,16 +16,16 @@
 
 package com.rackspace.salus.policy.manage.web.model.validator;
 
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCU;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
 
-public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolicyCU> {
+public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolicyCreate> {
   @Override
-  protected Enum getScope(MetadataPolicyCU policy) {
+  protected Enum getScope(MetadataPolicyCreate policy) {
     return policy.getScope();
   }
 
   @Override
-  protected boolean isSubscopeSet(MetadataPolicyCU policy) {
+  protected boolean isSubscopeSet(MetadataPolicyCreate policy) {
     return policy.getSubscope() != null && !policy.getSubscope().isBlank();
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model.validator;
+
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCU;
+
+public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolicyCU> {
+  @Override
+  protected Enum getScope(MetadataPolicyCU policy) {
+    return policy.getScope();
+  }
+
+  @Override
+  protected boolean isSubscopeSet(MetadataPolicyCU policy) {
+    return policy.getSubscope() != null && !policy.getSubscope().isBlank();
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MetadataPolicyCreateValidator.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.policy.manage.web.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
 import com.rackspace.salus.telemetry.model.PolicyScope;
+import org.apache.commons.lang3.StringUtils;
 
 public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolicyCreate> {
   @Override
@@ -27,6 +28,6 @@ public class MetadataPolicyCreateValidator extends PolicyValidator<MetadataPolic
 
   @Override
   protected boolean isSubscopeSet(MetadataPolicyCreate policy) {
-    return policy.getSubscope() != null && !policy.getSubscope().isBlank();
+    return StringUtils.isNotBlank(policy.getSubscope());
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.policy.manage.web.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.telemetry.model.PolicyScope;
+import org.apache.commons.lang3.StringUtils;
 
 public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyCreate> {
   @Override
@@ -27,6 +28,6 @@ public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyC
 
   @Override
   protected boolean isSubscopeSet(MonitorPolicyCreate policy) {
-    return policy.getSubscope() != null && !policy.getSubscope().isBlank();
+    return StringUtils.isNotBlank(policy.getSubscope());
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
@@ -17,10 +17,11 @@
 package com.rackspace.salus.policy.manage.web.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.telemetry.model.PolicyScope;
 
 public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyCreate> {
   @Override
-  protected Enum getScope(MonitorPolicyCreate policy) {
+  protected PolicyScope getScope(MonitorPolicyCreate policy) {
     return policy.getScope();
   }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/PolicyValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/PolicyValidator.java
@@ -33,6 +33,6 @@ public abstract class PolicyValidator<T> implements ConstraintValidator<ValidPol
             (!getScope(value).equals(PolicyScope.GLOBAL) && isSubscopeSet(value));
   }
 
-  protected abstract Enum getScope(T value);
+  protected abstract PolicyScope getScope(T value);
   protected abstract boolean isSubscopeSet(T value);
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/ValidPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/ValidPolicy.java
@@ -30,7 +30,7 @@ import javax.validation.Payload;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Constraint(validatedBy = {MonitorPolicyCreateValidator.class})
+@Constraint(validatedBy = {MonitorPolicyCreateValidator.class, MetadataPolicyCreateValidator.class})
 public @interface ValidPolicy {
 
   String message() default "subscope must be set for any non-global policy but not for global policies";

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -20,7 +20,9 @@
 
   <include resource="org/springframework/boot/logging/logback/defaults.xml" />
   <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
-  <include resource="logback-fluency.xml" />
+  <springProfile name="production">
+    <include resource="logback-fluency.xml" />
+  </springProfile>
 
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagementTest.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.policy.manage.config.DatabaseConfig;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.entities.Policy;
+import com.rackspace.salus.telemetry.entities.Resource;
+import com.rackspace.salus.telemetry.entities.TenantMetadata;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
+import com.rackspace.salus.telemetry.messaging.PolicyEvent;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.repositories.MetadataPolicyRepository;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.PolicyRepository;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@DataJpaTest(showSql = false)
+@Import({PolicyManagement.class, MetadataPolicyManagement.class,
+    TenantManagement.class, DatabaseConfig.class})
+public class MetadataPolicyManagementTest {
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Captor
+  ArgumentCaptor<PolicyEvent> policyEventArg;
+
+  @MockBean
+  PolicyEventProducer policyEventProducer;
+
+  @Autowired
+  PolicyManagement policyManagement;
+
+  @Autowired
+  MetadataPolicyManagement metadataPolicyManagement;
+
+  @Autowired
+  TenantManagement tenantManagement;
+
+  @Autowired
+  PolicyRepository policyRepository;
+
+  @Autowired
+  MetadataPolicyRepository metadataPolicyRepository;
+
+  @Autowired
+  TenantMetadataRepository tenantMetadataRepository;
+
+  @Autowired
+  ResourceRepository resourceRepository;
+
+  @Autowired
+  MonitorRepository monitorRepository;
+
+  @MockBean
+  EntityManager entityManager;
+
+  @Mock
+  TypedQuery query;
+
+  private MetadataPolicy defaultMetadataPolicy;
+
+  @Before
+  public void setup() {
+    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValueType(MetadataValueType.STRING)
+        .setSubscope(RandomStringUtils.randomAlphabetic(10))
+        .setScope(PolicyScope.ACCOUNT_TYPE);
+
+    defaultMetadataPolicy = metadataPolicyRepository.save(policy);
+  }
+
+  @Test
+  public void testGetMetadataPolicy() {
+    Optional<MetadataPolicy> p = metadataPolicyManagement.getMetadataPolicy(defaultMetadataPolicy.getId());
+
+    assertTrue(p.isPresent());
+    MetadataPolicy mp = p.get();
+    assertThat(mp.getId(), notNullValue());
+    assertThat(mp.getScope(), isOneOf(PolicyScope.values()));
+    assertThat(mp.getScope(), equalTo(defaultMetadataPolicy.getScope()));
+    assertThat(mp.getSubscope(), equalTo(defaultMetadataPolicy.getSubscope()));
+    assertThat(mp.getMonitorType(), equalTo(defaultMetadataPolicy.getMonitorType()));
+    assertThat(mp.getValueType(), equalTo(defaultMetadataPolicy.getValueType()));
+    assertThat(mp.getKey(), equalTo(defaultMetadataPolicy.getKey()));
+    assertThat(mp.getValue(), equalTo(defaultMetadataPolicy.getValue()));
+  }
+
+  @Test
+  public void testCreateMetadataPolicy() {
+    // Generate a random tenant and account type for the test
+    String accountType = RandomStringUtils.randomAlphabetic(10);
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    // Store a default tenant in the db for that account type
+    tenantMetadataRepository.save(new TenantMetadata()
+        .setAccountType(accountType)
+        .setTenantId(tenantId)
+        .setMetadata(Collections.emptyMap()));
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(PolicyScope.ACCOUNT_TYPE)
+        .setSubscope(accountType)
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping);
+
+    MetadataPolicy policy = metadataPolicyManagement.createMetadataPolicy(policyCreate);
+    assertThat(policy.getId(), notNullValue());
+    assertThat(policy.getScope(), equalTo(policyCreate.getScope()));
+    assertThat(policy.getSubscope(), equalTo(policyCreate.getSubscope()));
+    assertThat(policy.getMonitorType(), equalTo(policyCreate.getMonitorType()));
+    assertThat(policy.getValueType(), equalTo(policyCreate.getValueType()));
+    assertThat(policy.getKey(), equalTo(policyCreate.getKey()));
+    assertThat(policy.getValue(), equalTo(policyCreate.getValue()));
+
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId)
+    ));
+
+    verifyNoMoreInteractions(policyEventProducer);
+  }
+
+  @Test
+  public void testCreateMetadataPolicy_multipleTenants() {
+    List<String> tenantIds = createMultipleTenants("metadataKey");
+
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(PolicyScope.GLOBAL)
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.x509_cert);
+
+    mockGetTenantsUsingPolicyKey(tenantIds);
+
+    MetadataPolicy policy = metadataPolicyManagement.createMetadataPolicy(policyCreate);
+    assertThat(policy.getId(), notNullValue());
+    assertThat(policy.getScope(), equalTo(policyCreate.getScope()));
+    assertThat(policy.getSubscope(), equalTo(policyCreate.getSubscope()));
+    assertThat(policy.getMonitorType(), equalTo(policyCreate.getMonitorType()));
+    assertThat(policy.getValueType(), equalTo(policyCreate.getValueType()));
+    assertThat(policy.getKey(), equalTo(policyCreate.getKey()));
+    assertThat(policy.getValue(), equalTo(policyCreate.getValue()));
+
+    verify(policyEventProducer, times(5)).sendPolicyEvent(policyEventArg.capture());
+    assertThat(policyEventArg.getAllValues(), hasSize(5));
+
+    List<MetadataPolicyEvent> expected = tenantIds.stream()
+        .map(t -> (MetadataPolicyEvent) new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(t)).collect(Collectors.toList());
+
+    assertThat(policyEventArg.getAllValues(), containsInAnyOrder(expected.toArray()));
+    verifyNoMoreInteractions(policyEventProducer);
+  }
+
+  @Test
+  public void testCreateMetadataPolicy_differentMonitorType() {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(defaultMetadataPolicy.getScope())
+        .setSubscope(defaultMetadataPolicy.getSubscope())
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(defaultMetadataPolicy.getKey())
+        .setValueType(MetadataValueType.DURATION)
+        .setMonitorType(MonitorType.net_response);
+
+    assertThat(policyCreate.getMonitorType(), not(equalTo(defaultMetadataPolicy.getMonitorType())));
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    MetadataPolicy policy = metadataPolicyManagement.createMetadataPolicy(policyCreate);
+    assertThat(policy.getId(), notNullValue());
+    assertThat(policy.getScope(), equalTo(policyCreate.getScope()));
+    assertThat(policy.getSubscope(), equalTo(policyCreate.getSubscope()));
+    assertThat(policy.getMonitorType(), equalTo(policyCreate.getMonitorType()));
+    assertThat(policy.getValueType(), equalTo(policyCreate.getValueType()));
+    assertThat(policy.getKey(), equalTo(policyCreate.getKey()));
+    assertThat(policy.getValue(), equalTo(policyCreate.getValue()));
+
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId)
+    ));
+
+    verifyNoMoreInteractions(policyEventProducer);
+  }
+
+  @Test
+  public void testCreateMetadataPolicy_duplicatePolicy() {
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(defaultMetadataPolicy.getScope())
+        .setSubscope(defaultMetadataPolicy.getSubscope())
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(defaultMetadataPolicy.getKey())
+        .setValueType(MetadataValueType.DURATION)
+        .setMonitorType(defaultMetadataPolicy.getMonitorType());
+
+    assertThatThrownBy(() -> metadataPolicyManagement.createMetadataPolicy(policyCreate))
+      .isInstanceOf(AlreadyExistsException.class)
+      .hasMessage(
+          String.format("Policy already exists with scope:subscope:type:key of %s:%s:%s:%s",
+              policyCreate.getScope(),
+              policyCreate.getSubscope(),
+              policyCreate.getMonitorType(),
+              policyCreate.getKey())
+      );
+  }
+
+  /**
+   * This test verifies that the PolicyEvent contains the id that is actually stored in the db.
+   */
+  @Test
+  public void testPolicyEvent_policyIdExists() {
+    // Generate a random tenant and account type for the test
+    String accountType = RandomStringUtils.randomAlphabetic(10);
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    // Store a default tenant in the db for that account type
+    tenantMetadataRepository.save(new TenantMetadata()
+        .setAccountType(accountType)
+        .setTenantId(tenantId)
+        .setMetadata(Collections.emptyMap()));
+
+    // Create a monitor
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(PolicyScope.ACCOUNT_TYPE)
+        .setSubscope(accountType)
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping);
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    Policy policy = metadataPolicyManagement.createMetadataPolicy(policyCreate);
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+
+    // Verify the Policy Event looks correct
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId)
+    ));
+
+    // Verify the monitor in the PolicyEvent can be found
+    Optional<MetadataPolicy> saved = metadataPolicyManagement
+        .getMetadataPolicy(policyEventArg.getValue().getPolicyId());
+    assertTrue(saved.isPresent());
+
+    MetadataPolicy p = saved.get();
+    assertThat(p.getScope(), equalTo(policyCreate.getScope()));
+    assertThat(p.getSubscope(), equalTo(policyCreate.getSubscope()));
+    assertThat(p.getMonitorType(), equalTo(policyCreate.getMonitorType()));
+    assertThat(p.getValueType(), equalTo(policyCreate.getValueType()));
+    assertThat(p.getKey(), equalTo(policyCreate.getKey()));
+    assertThat(p.getValue(), equalTo(policyCreate.getValue()));
+
+    verifyNoMoreInteractions(policyEventProducer);
+  }
+
+  /**
+   * This test saves numerous policies to the database while also adding certain ones to
+   * the `expected` list.  This list is populated with those policies that we would expect
+   * to be effective for the particular test tenant and account type.
+   */
+  @Test
+  public void testGetEffectiveMonitorPoliciesForTenant() {
+    String tenantId = RandomStringUtils.randomNumeric(5);
+    String testAccountType = "TestAccountType";
+
+    tenantMetadataRepository.save(new TenantMetadata()
+        .setTenantId(tenantId)
+        .setAccountType(testAccountType)
+        .setMetadata(Collections.emptyMap()));
+
+    List<Policy> expected = new ArrayList<>();
+
+    // Create a global policy that will not be overridden
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("OnlyGlobal")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setScope(PolicyScope.GLOBAL)));
+
+    // Create global policy that will be overridden
+    policyRepository.save(
+        new MetadataPolicy()
+            .setValue(RandomStringUtils.randomAlphabetic(10))
+            .setKey("OverriddenByAccountType")
+            .setValueType(MetadataValueType.STRING)
+            .setMonitorType(MonitorType.ping)
+            .setScope(PolicyScope.GLOBAL)
+    );
+
+    // Create a global policy with the same key but different monitor type
+    // that will not be overridden.
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("OnlyGlobal")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.procstat)
+        .setScope(PolicyScope.GLOBAL)));
+
+    // Create AccountType policy that will override global
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("OverriddenByAccountType")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setSubscope(testAccountType)
+        .setScope(PolicyScope.ACCOUNT_TYPE)));
+
+    // Create AccountType policy that will be overridden by tenant
+    policyRepository.save(
+        new MetadataPolicy()
+            .setValue(RandomStringUtils.randomAlphabetic(10))
+            .setKey("OverriddenByTenant")
+            .setValueType(MetadataValueType.STRING)
+            .setMonitorType(MonitorType.ping)
+            .setSubscope(testAccountType)
+            .setScope(PolicyScope.ACCOUNT_TYPE)
+    );
+
+    // Create AccountType policy that will not be overridden
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("UniqueAccountPolicy")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setSubscope(testAccountType)
+        .setScope(PolicyScope.ACCOUNT_TYPE)));
+
+    // Create AccountType policy that is irrelevant to our test tenant.
+    policyRepository.save(
+        new MetadataPolicy()
+            .setValue(RandomStringUtils.randomAlphabetic(10))
+            .setKey("IrrelevantAccountType")
+            .setValueType(MetadataValueType.STRING)
+            .setMonitorType(MonitorType.ping)
+            .setSubscope("IrrelevantAccountType")
+            .setScope(PolicyScope.ACCOUNT_TYPE)
+    );
+
+    // Create Tenant policy that will override AccountType
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("OverriddenByTenant")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setSubscope(tenantId)
+        .setScope(PolicyScope.TENANT)));
+
+    // Create Tenant policy that will not be overridden
+    expected.add(policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey("UniqueTenantPolicy")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setSubscope(tenantId)
+        .setScope(PolicyScope.TENANT)));
+
+    // Create Tenant policy that is irrelevant to our test tenant.
+    policyRepository.save(
+        new MetadataPolicy()
+            .setValue(RandomStringUtils.randomAlphabetic(10))
+            .setKey("IrrelevantTenant")
+            .setValueType(MetadataValueType.STRING)
+            .setMonitorType(MonitorType.ping)
+            .setSubscope(RandomStringUtils.randomAlphabetic(10))
+            .setScope(PolicyScope.TENANT)
+    );
+
+    List<MetadataPolicy> effectivePolicies = metadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(tenantId);
+
+    assertThat(effectivePolicies, hasSize(6));
+    assertThat(effectivePolicies, containsInAnyOrder(expected.toArray()));
+  }
+
+  @Test
+  public void testRemoveMetadataPolicy() {
+    String tenantId = createSingleTenant();
+
+    // Create a policy to remove
+    MetadataPolicy saved = (MetadataPolicy) policyRepository.save(new MetadataPolicy()
+        .setValue(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.disk)
+        .setScope(PolicyScope.GLOBAL));
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    metadataPolicyManagement.removeMetadataPolicy(saved.getId());
+
+    verify(entityManager).createNamedQuery("Monitor.getTenantsUsingTemplateVariable", String.class);
+    verify(query).setParameter("variable", saved.getKey());
+    verify(query).getResultList();
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(saved.getId())
+            .setTenantId(tenantId)
+    ));
+
+    Optional<MetadataPolicy> removed = metadataPolicyManagement.getMetadataPolicy(
+        policyEventArg.getValue().getPolicyId());
+
+    assertTrue(removed.isEmpty());
+
+    verifyNoMoreInteractions(entityManager, query, policyEventProducer);
+  }
+
+  @Test
+  public void testRemoveMetadataPolicy_doesntExist() {
+    UUID id = UUID.randomUUID();
+    assertThatThrownBy(() -> metadataPolicyManagement.removeMetadataPolicy(id))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessage(
+            String.format("No policy found with id %s", id)
+        );
+  }
+
+  private String createSingleTenant() {
+    Resource resource = podamFactory.manufacturePojo(Resource.class);
+    return resourceRepository.save(resource).getTenantId();
+  }
+
+  private List<String> createMultipleTenants(String metadataKey) {
+    // update this to create tenants that use the field
+    List<Resource> resources = podamFactory.manufacturePojo(ArrayList.class, Resource.class);
+    return StreamSupport.stream(resourceRepository.saveAll(resources).spliterator(), false)
+        .map(Resource::getTenantId)
+        .collect(Collectors.toList());
+  }
+
+  private void mockGetTenantsUsingPolicyKey(List<String> tenantIds) {
+    when(entityManager.createNamedQuery(anyString(), any())).thenReturn(query);
+    when(query.setParameter(anyString(), any())).thenReturn(query);
+    when(query.getResultList()).thenReturn(tenantIds);
+  }
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MetadataPolicyManagementTest.java
@@ -295,8 +295,7 @@ public class MetadataPolicyManagementTest {
         .setAccountType(accountType)
         .setTenantId(tenantId)
         .setMetadata(Collections.emptyMap()));
-
-    // Create a monitor
+    
     MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
         .setScope(PolicyScope.ACCOUNT_TYPE)
         .setSubscope(accountType)

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
@@ -81,6 +81,9 @@ public class MonitorPolicyManagementTest {
   PolicyEventProducer policyEventProducer;
 
   @Autowired
+  PolicyManagement policyManagement;
+
+  @Autowired
   MonitorPolicyManagement monitorPolicyManagement;
 
   @Autowired
@@ -416,7 +419,7 @@ public class MonitorPolicyManagementTest {
 
     List<String> expectedIds = resources.stream().map(Resource::getTenantId).collect(Collectors.toList());
 
-    List<String> tenantIds = monitorPolicyManagement.getAllDistinctTenantIds();
+    List<String> tenantIds = policyManagement.getAllDistinctTenantIds();
 
     assertThat(tenantIds, notNullValue());
     assertThat(tenantIds, hasSize(expectedIds.size()));

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
@@ -69,7 +69,8 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
 @DataJpaTest(showSql = false)
-@Import({MonitorPolicyManagement.class, TenantManagement.class, DatabaseConfig.class})
+@Import({PolicyManagement.class, MonitorPolicyManagement.class,
+    TenantManagement.class, DatabaseConfig.class})
 public class MonitorPolicyManagementTest {
 
   private PodamFactory podamFactory = new PodamFactoryImpl();

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiControllerTest.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import static com.rackspace.salus.test.JsonTestUtils.readContent;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.policy.manage.services.MetadataPolicyManagement;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(MetadataPolicyApiController.class)
+public class MetadataPolicyApiControllerTest {
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Autowired
+  MockMvc mvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  MetadataPolicyManagement metadataPolicyManagement;
+
+  @Test
+  public void testGetById() throws Exception {
+    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
+        .setValue("test_value")
+        .setKey("test_key")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setScope(PolicyScope.GLOBAL)
+        .setId(UUID.fromString("5cb19cb3-03e3-4a71-8051-cc7c4bc0c029"))
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+
+    when(metadataPolicyManagement.getMetadataPolicy(any()))
+        .thenReturn(Optional.of(policy));
+
+    mvc.perform(get(
+        "/api/admin/policy/metadata/{uuid}", policy.getId())
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("PolicyApiControllerTest/global_metadata_policy.json"), true));
+
+    verify(metadataPolicyManagement).getMetadataPolicy(policy.getId());
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+
+  @Test
+  public void testGetAllMetadataPolicies() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    final List<MetadataPolicy> listOfPolicies = podamFactory.manufacturePojo(ArrayList.class, MetadataPolicy.class);
+
+    // Use the APIs default Pageable settings
+    int page = 0;
+    int pageSize = 20;
+
+    Page<MetadataPolicy> pageOfPolicies = new PageImpl<>(
+        listOfPolicies,
+        PageRequest.of(page, pageSize),
+        listOfPolicies.size());
+
+    when(metadataPolicyManagement.getAllMetadataPolicies(any()))
+        .thenReturn(pageOfPolicies);
+
+    mvc.perform(get(
+        "/api/admin/policy/metadata", tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.content.*", hasSize(5)))
+        .andExpect(jsonPath("$.totalPages", equalTo(1)))
+        .andExpect(jsonPath("$.totalElements", equalTo(5)));
+
+    verify(metadataPolicyManagement).getAllMetadataPolicies(PageRequest.of(page, pageSize));
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+
+  @Test
+  public void testGetEffectivePoliciesByTenantId() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    final List<MetadataPolicy> listOfPolicies = podamFactory.manufacturePojo(ArrayList.class, MetadataPolicy.class);
+    when(metadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(anyString()))
+        .thenReturn(listOfPolicies);
+
+    mvc.perform(get(
+        "/api/admin/policy/metadata/effective/{tenantId}", tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(objectMapper.writeValueAsString(listOfPolicies)));
+
+    verify(metadataPolicyManagement).getEffectiveMetadataPoliciesForTenant(tenantId);
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+
+  @Test
+  public void testCreatePolicy() throws Exception {
+    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
+        .setValue("test_value")
+        .setKey("test_key")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setScope(PolicyScope.GLOBAL)
+        .setId(UUID.fromString("5cb19cb3-03e3-4a71-8051-cc7c4bc0c029"))
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+
+    when(metadataPolicyManagement.createMetadataPolicy(any()))
+        .thenReturn(policy);
+
+    // All we need is a valid create object; doesn't matter what else is set.
+    MetadataPolicyCreate policyCreate = new MetadataPolicyCreate()
+        .setScope(PolicyScope.ACCOUNT_TYPE)
+        .setSubscope(RandomStringUtils.randomAlphabetic(10))
+        .setKey(RandomStringUtils.randomAlphabetic(10))
+        .setValue(RandomStringUtils.randomAlphabetic(10));
+
+    mvc.perform(post(
+        "/api/admin/policy/metadata")
+        .content(objectMapper.writeValueAsString(policyCreate))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("PolicyApiControllerTest/global_metadata_policy.json"), true));
+
+    verify(metadataPolicyManagement).createMetadataPolicy(policyCreate);
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+
+  @Test
+  public void testUpdatePolicy() throws Exception {
+    MetadataPolicy policy = (MetadataPolicy) new MetadataPolicy()
+        .setValue("test_value")
+        .setKey("test_key")
+        .setValueType(MetadataValueType.STRING)
+        .setMonitorType(MonitorType.ping)
+        .setScope(PolicyScope.GLOBAL)
+        .setId(UUID.fromString("5cb19cb3-03e3-4a71-8051-cc7c4bc0c029"))
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
+
+    when(metadataPolicyManagement.updateMetadataPolicy(any(), any()))
+        .thenReturn(policy);
+
+    // All we need is a valid update object; doesn't matter what values are set.
+    MetadataPolicyUpdate policyUpdate = new MetadataPolicyUpdate()
+        .setValue(RandomStringUtils.randomAlphabetic(10));
+
+    UUID id = UUID.randomUUID();
+    mvc.perform(put(
+        "/api/admin/policy/metadata/{uuid}", id)
+        .content(objectMapper.writeValueAsString(policyUpdate))
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(
+            readContent("PolicyApiControllerTest/global_metadata_policy.json"), true));
+
+    verify(metadataPolicyManagement).updateMetadataPolicy(id, policyUpdate);
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+
+  @Test
+  public void testRemoveMetadataPolicy() throws Exception {
+    UUID id = UUID.randomUUID();
+    mvc.perform(delete(
+        "/api/admin/policy/metadata/{uuid}", id)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isNoContent());
+
+    verify(metadataPolicyManagement).removeMetadataPolicy(id);
+    verifyNoMoreInteractions(metadataPolicyManagement);
+  }
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
@@ -67,9 +67,6 @@ public class MonitorPolicyApiControllerTest {
   @MockBean
   MonitorPolicyManagement monitorPolicyManagement;
 
-  // A timestamp to be used in tests that translates to "1970-01-02T03:46:40Z"
-  private static final Instant DEFAULT_TIMESTAMP = Instant.ofEpochSecond(100000);
-
   @Test
   public void testGetById() throws Exception {
     MonitorPolicy policy = (MonitorPolicy) new MonitorPolicy()
@@ -77,8 +74,8 @@ public class MonitorPolicyApiControllerTest {
         .setName("Test Name")
         .setScope(PolicyScope.GLOBAL)
         .setId(UUID.fromString("c0f88d34-2833-4ebb-926c-3601795901f9"))
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     when(monitorPolicyManagement.getMonitorPolicy(any()))
         .thenReturn(Optional.of(policy));
@@ -91,7 +88,7 @@ public class MonitorPolicyApiControllerTest {
         .andExpect(content()
             .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(content().json(
-            readContent("PolicyApiControllerTest/global_policy.json"), true));
+            readContent("PolicyApiControllerTest/global_monitor_policy.json"), true));
 
     verify(monitorPolicyManagement).getMonitorPolicy(policy.getId());
     verifyNoMoreInteractions(monitorPolicyManagement);
@@ -124,8 +121,8 @@ public class MonitorPolicyApiControllerTest {
         .setName("Test Name")
         .setScope(PolicyScope.GLOBAL)
         .setId(UUID.fromString("c0f88d34-2833-4ebb-926c-3601795901f9"))
-        .setCreatedTimestamp(DEFAULT_TIMESTAMP)
-        .setUpdatedTimestamp(DEFAULT_TIMESTAMP);
+        .setCreatedTimestamp(Instant.EPOCH)
+        .setUpdatedTimestamp(Instant.EPOCH);
 
     when(monitorPolicyManagement.createMonitorPolicy(any()))
         .thenReturn(policy);
@@ -146,7 +143,7 @@ public class MonitorPolicyApiControllerTest {
         .andExpect(content()
             .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(content().json(
-            readContent("PolicyApiControllerTest/global_policy.json"), true));
+            readContent("PolicyApiControllerTest/global_monitor_policy.json"), true));
 
     verify(monitorPolicyManagement).createMonitorPolicy(policyCreate);
     verifyNoMoreInteractions(monitorPolicyManagement);
@@ -175,6 +172,4 @@ public class MonitorPolicyApiControllerTest {
     verify(monitorPolicyManagement).removeMonitorPolicy(id);
     verifyNoMoreInteractions(monitorPolicyManagement);
   }
-
-
 }

--- a/src/test/resources/PolicyApiControllerTest/global_metadata_policy.json
+++ b/src/test/resources/PolicyApiControllerTest/global_metadata_policy.json
@@ -1,0 +1,11 @@
+{
+  "id": "5cb19cb3-03e3-4a71-8051-cc7c4bc0c029",
+  "scope": "GLOBAL",
+  "subscope": null,
+  "monitorType": "ping",
+  "valueType": "STRING",
+  "key": "test_key",
+  "value": "test_value",
+  "createdTimestamp": "1970-01-01T00:00:00Z",
+  "updatedTimestamp": "1970-01-01T00:00:00Z"
+}

--- a/src/test/resources/PolicyApiControllerTest/global_metadata_policy.json
+++ b/src/test/resources/PolicyApiControllerTest/global_metadata_policy.json
@@ -2,6 +2,7 @@
   "id": "5cb19cb3-03e3-4a71-8051-cc7c4bc0c029",
   "scope": "GLOBAL",
   "subscope": null,
+  "targetClassName": "Monitor",
   "monitorType": "ping",
   "valueType": "STRING",
   "key": "test_key",

--- a/src/test/resources/PolicyApiControllerTest/global_monitor_policy.json
+++ b/src/test/resources/PolicyApiControllerTest/global_monitor_policy.json
@@ -4,6 +4,6 @@
   "subscope": null,
   "name": "Test Name",
   "monitorId": "32e3ac07-5a80-4d56-8519-f66eb66ec6b6",
-  "createdTimestamp": "1970-01-02T03:46:40Z",
-  "updatedTimestamp": "1970-01-02T03:46:40Z"
+  "createdTimestamp": "1970-01-01T00:00:00Z",
+  "updatedTimestamp": "1970-01-01T00:00:00Z"
 }


### PR DESCRIPTION
https://github.com/racker/salus-policy-management/pull/13 needs to be merged into this first.

# What

Adds the ability to CRUD metadata policies.

# How

* Created a new `MetadataPolicyManagement` service.
* Also created `PolicyManagement` and moved some of the common utils from `MonitorPolicyManagement` over there to be shared. 
* I've not exposed the `PolicyManagement` methods via the API yet, but that could be something that's useful to us in future.
* `getEffectiveMetadataPoliciesForTenant` was not moved to the shared service since it is slightly different (uses Pair) from what Monitor Policies do, but there's potential for consolidating them.

## How to test

Run tests.

# Why

We can use this to store default values that can be used within monitor/task configurations.

For example, the default `interval` for all monitors could be stored in here as:

```
scope: GLOBAL
subscope: null
monitorType: null
valueType: DURATION
key: interval
value: 60
```

Any new monitor created would use this unless the value was specifically overridden by the customer.

If we were asked by support or decided to change this value ourselves at any point, we can simply modify this one policy and it would cause all monitors using it to also be updated.

This service also allows different values to be set for different monitor types or account types.  This would likely come in useful for something like a `timeout`.  The default timeout for a ping monitor would likely be different than that used by an http monitor.

# TODO

* Monitor Management PR to handle the new `MetadataPolicyEvent`s.
* Monitor Management PR to remove `@NotNull` from fields that we would want to override with a template if null is set.
