### PR TITLE
fix exception handlers

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/RestExceptionHandler.java
@@ -37,12 +37,6 @@ public class RestExceptionHandler extends
     super(errorAttributes);
   }
 
-  @ExceptionHandler({IllegalArgumentException.class})
-  public ResponseEntity<?> handleBadRequest(
-      HttpServletRequest request) {
-    return respondWith(request, HttpStatus.BAD_REQUEST);
-  }
-
   @ExceptionHandler({NotFoundException.class})
   public ResponseEntity<?> handleNotFound(
       HttpServletRequest request) {


### PR DESCRIPTION
fix the following:
Caused by: java.lang.IllegalStateException: Ambiguous @ExceptionHandler method mapped for [class java.lang.IllegalArgumentException]: {public org.springframework.http.ResponseEntity com.rackspace.salus.policy.manage.web.controller.RestExceptionHandler.handleBadRequest(javax.servlet.http.HttpServletRequest), public org.springframework.http.ResponseEntity com.rackspace.salus.common.web.AbstractRestExceptionHandler.handleBadRequest(javax.servlet.http.HttpServletRequest,java.lang.Exception)}
