### PR TITLE
Adding zipkin support, but disabled by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
       <artifactId>spring-cloud-starter-sleuth</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-zipkin</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,5 @@ spring:
   jackson:
     mapper:
       default-view-inclusion: true
+  zipkin:
+    enabled: false


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-725

# What

Preparing support for [Zipkin with Spring Cloud Sleuth](https://cloud.spring.io/spring-cloud-static/spring-cloud-sleuth/2.2.0.RELEASE/reference/html/#sending-spans-to-zipkin), but disabling it by default until zipkin endpoint is decided and deployed.