### PR TITLE
Updated unit test to use mysql testcontainers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2019 Rackspace US, Inc.
+  ~ Copyright 2020 Rackspace US, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -83,8 +83,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-test</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,7 +19,7 @@ spring:
     platform: mysql
   kafka:
     listener:
-      # this will allow for to start consumer of a particular topic before the producer
+      # this will allow for us to start consumer of a particular topic before the producer
       missing-topics-fatal: false
 logging:
   level:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,10 @@ spring:
     url: jdbc:mysql://localhost:3306/default?verifyServerCertificate=false&useSSL=false&requireSSL=false
     driver-class-name: com.mysql.cj.jdbc.Driver
     platform: mysql
+  kafka:
+    listener:
+      # this will allow for to start consumer of a particular topic before the producer
+      missing-topics-fatal: false
 logging:
   level:
     com.rackspace.salus: debug

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.PolicyRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -77,6 +78,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({PolicyManagement.class, MonitorMetadataPolicyManagement.class,
     TenantManagement.class, DatabaseConfig.class})

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.rackspace.salus.policy.manage.services;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -23,28 +24,28 @@ import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.rackspace.salus.policy.manage.config.DatabaseConfig;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.entities.Resource;
-import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.entities.MonitorPolicy;
 import com.rackspace.salus.telemetry.entities.Policy;
+import com.rackspace.salus.telemetry.entities.Resource;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
+import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
+import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
+import com.rackspace.salus.telemetry.messaging.PolicyEvent;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.repositories.MonitorPolicyRepository;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
 import com.rackspace.salus.telemetry.repositories.PolicyRepository;
 import com.rackspace.salus.telemetry.repositories.ResourceRepository;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
-import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
-import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
-import com.rackspace.salus.telemetry.messaging.MonitorPolicyEvent;
-import com.rackspace.salus.telemetry.messaging.PolicyEvent;
-import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +69,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({PolicyManagement.class, MonitorPolicyManagement.class,
     TenantManagement.class, DatabaseConfig.class})

--- a/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/TenantManagementTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.rackspace.salus.policy.manage.config.DatabaseConfig;
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import com.rackspace.salus.telemetry.messaging.TenantPolicyChangeEvent;
 import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
-import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -45,6 +46,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
 @DataJpaTest(showSql = false)
 @Import({TenantManagement.class, DatabaseConfig.class})
 public class TenantManagementTest {


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-738

# What

The Spring Boot upgrade from 2.1.8 to 2.2.4 included an upgrade of h2 from 1.4.199 to 1.4.200. Even though that version of h2 brings some nice features like json data type support, it also became more picky (correctly so) about the SQL used in the flyway migration files.

With the Spring Boot 2.2.4 upgrade the default must have changed for `spring.kafka.listener.missing-topics-fatal` from false to true or it's a new condition spring kafka checks. In any case, when starting one of our kafka-consuming apps locally it was failing to start since I had a fresh kafka container without the topic it wanted. It's a good property and default to have in production, but annoying locally.

# How

Use the new `@EnableTestContainersDatabase` annotation provided by https://github.com/racker/salus-test/pull/7 to activate mysql testcontainers support in place of h2 during unit tests.

# How to test

Existing unit tests

# Depends on

https://github.com/racker/salus-test/pull/7