### PR TITLE
Enable role based json views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-sleuth</artifactId>
     </dependency>
@@ -65,6 +69,11 @@
     <dependency>
       <groupId>com.rackspace.salus</groupId>
       <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-common</artifactId>
       <version>0.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
@@ -19,12 +19,14 @@ package com.rackspace.salus.policy.manage;
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
 import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.util.DumpConfigProperties;
+import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @EnableSalusKafkaMessaging
 @EnableExtendedErrorAttributes
+@EnableRoleBasedJsonViews
 public class PolicyManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
@@ -16,7 +16,7 @@
 
 package com.rackspace.salus.policy.manage.services;
 
-import static com.rackspace.salus.common.messaging.KafkaMessageKeyBuilder.buildMessageKey;
+import static com.rackspace.salus.telemetry.messaging.KafkaMessageKeyBuilder.buildMessageKey;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.PolicyEvent;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -25,7 +25,7 @@ import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import com.rackspace.salus.telemetry.model.TargetClassName;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -65,7 +65,6 @@ public class MetadataPolicyApiController {
   @GetMapping("/admin/policy/metadata/monitor/{uuid}")
   @ApiOperation(value = "Gets specific Metadata Policy by id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Metadata Policy Retrieved")})
-  @JsonView(View.Admin.class)
   public MonitorMetadataPolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
     return new MonitorMetadataPolicyDTO(
         monitorMetadataPolicyManagement.getMetadataPolicy(uuid).orElseThrow(
@@ -75,7 +74,6 @@ public class MetadataPolicyApiController {
   @GetMapping("/admin/policy/metadata/monitor/effective/{tenantId}")
   @ApiOperation(value = "Gets effective Metadata policies by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
-  @JsonView(View.Admin.class)
   public List<MonitorMetadataPolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
     return monitorMetadataPolicyManagement.getEffectiveMetadataPoliciesForTenant(tenantId)
         .stream().map(MonitorMetadataPolicyDTO::new).collect(Collectors.toList());
@@ -84,7 +82,6 @@ public class MetadataPolicyApiController {
   @GetMapping("/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
   @ApiOperation(value = "Gets effective Metadata policies by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policy values Retrieved")})
-  @JsonView(View.Admin.class)
   public Map<String, MonitorMetadataPolicyDTO> getPolicyMap(
       @PathVariable String tenantId, @PathVariable TargetClassName className, @PathVariable MonitorType monitorType) {
     return monitorMetadataPolicyManagement.getMetadataPoliciesForTenantAndType(tenantId, className, monitorType)
@@ -99,7 +96,6 @@ public class MetadataPolicyApiController {
   @GetMapping("/admin/policy/metadata/monitor")
   @ApiOperation(value = "Gets all monitor metadata policies")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
-  @JsonView(View.Admin.class)
   public PagedContent<MonitorMetadataPolicyDTO> getAllMetadataPolicies(Pageable page) {
     return PagedContent.fromPage(monitorMetadataPolicyManagement.getAllMetadataPolicies(page)
         .map(MonitorMetadataPolicyDTO::new));
@@ -109,7 +105,6 @@ public class MetadataPolicyApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new monitor metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Metadata Policy")})
-  @JsonView(View.Admin.class)
   public MonitorMetadataPolicyDTO createMonitorMetadata(@Valid @RequestBody final MonitorMetadataPolicyCreate input)
       throws IllegalArgumentException {
     return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createMetadataPolicy(input));
@@ -118,7 +113,6 @@ public class MetadataPolicyApiController {
   @PutMapping("/admin/policy/metadata/monitor/{uuid}")
   @ApiOperation(value = "Updates a monitor metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully Created Metadata Policy")})
-  @JsonView(View.Admin.class)
   public MonitorMetadataPolicyDTO update(@PathVariable UUID uuid, @Valid @RequestBody final MetadataPolicyUpdate input)
       throws IllegalArgumentException {
     return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.updateMetadataPolicy(uuid, input));
@@ -128,7 +122,6 @@ public class MetadataPolicyApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Metadata Policy Deleted")})
-  @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID uuid) {
     monitorMetadataPolicyManagement.removeMetadataPolicy(uuid);
   }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -16,16 +16,14 @@
 
 package com.rackspace.salus.policy.manage.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.policy.manage.services.MonitorMetadataPolicyManagement;
+import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import com.rackspace.salus.telemetry.model.TargetClassName;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
@@ -16,13 +16,11 @@
 
 package com.rackspace.salus.policy.manage.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
-import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
 import com.rackspace.salus.policy.manage.services.MonitorPolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
@@ -22,7 +22,7 @@ import com.rackspace.salus.policy.manage.services.MonitorPolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -59,7 +59,6 @@ public class MonitorPolicyApiController {
   @GetMapping("/admin/policy/monitors/{uuid}")
   @ApiOperation(value = "Gets specific Monitor Policy by id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Monitor Policy Retrieved")})
-  @JsonView(View.Admin.class)
   public MonitorPolicyDTO getById(@PathVariable UUID uuid) throws NotFoundException {
     return new MonitorPolicyDTO(
         monitorPolicyManagement.getMonitorPolicy(uuid).orElseThrow(
@@ -69,7 +68,6 @@ public class MonitorPolicyApiController {
   @GetMapping("/admin/policy/monitors/effective/{tenantId}")
   @ApiOperation(value = "Gets effective monitor policies by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
-  @JsonView(View.Admin.class)
   public List<MonitorPolicyDTO> getEffectivePoliciesByTenantId(@PathVariable String tenantId) {
     return monitorPolicyManagement.getEffectiveMonitorPoliciesForTenant(tenantId)
         .stream().map(MonitorPolicyDTO::new).collect(Collectors.toList());
@@ -78,7 +76,6 @@ public class MonitorPolicyApiController {
   @GetMapping("/admin/policy/monitors/effective/{tenantId}/ids")
   @ApiOperation(value = "Gets effective policy monitor ids by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Monitor policy ids retrieved")})
-  @JsonView(View.Admin.class)
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(@PathVariable String tenantId) {
     return monitorPolicyManagement.getEffectivePolicyMonitorIdsForTenant(tenantId);
   }
@@ -86,7 +83,6 @@ public class MonitorPolicyApiController {
   @GetMapping("/admin/policy/monitors")
   @ApiOperation(value = "Gets all monitor policies")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Policies Retrieved")})
-  @JsonView(View.Admin.class)
   public PagedContent<MonitorPolicyDTO> getAllMonitorPolicies(Pageable page) {
     return PagedContent.fromPage(monitorPolicyManagement.getAllMonitorPolicies(page)
         .map(MonitorPolicyDTO::new));
@@ -96,7 +92,6 @@ public class MonitorPolicyApiController {
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new Monitor for Tenant")
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
-  @JsonView(View.Admin.class)
   public MonitorPolicyDTO create(@Valid @RequestBody final MonitorPolicyCreate input)
       throws IllegalArgumentException {
     return new MonitorPolicyDTO(monitorPolicyManagement.createMonitorPolicy(input));
@@ -106,7 +101,6 @@ public class MonitorPolicyApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Monitor Policy")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Monitor Policy Deleted")})
-  @JsonView(View.Admin.class)
   public void delete(@PathVariable UUID uuid) {
     monitorPolicyManagement.removeMonitorPolicy(uuid);
   }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -16,12 +16,10 @@
 
 package com.rackspace.salus.policy.manage.web.controller;
 
-import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.policy.manage.services.TenantManagement;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -21,7 +21,7 @@ import com.rackspace.salus.policy.manage.services.TenantManagement;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -53,7 +53,6 @@ public class TenantApiController {
   @GetMapping("/public/account/{tenantId}")
   @ApiOperation(value = "Retrieves miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved tenant metadata")})
-  @JsonView(View.Public.class)
   public TenantMetadataDTO getTenantMetadata(@PathVariable String tenantId) {
     return new TenantMetadataDTO(
         tenantManagement.getMetadata(tenantId).orElseThrow(
@@ -63,7 +62,6 @@ public class TenantApiController {
   @PutMapping("/public/account/{tenantId}")
   @ApiOperation(value = "Creates or updates miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully updated tenant metadata")})
-  @JsonView(View.Public.class)
   public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
       @RequestBody TenantMetadataCU input) {
     return new TenantMetadataDTO(tenantManagement.upsertTenantMetadata(tenantId, input));
@@ -73,7 +71,6 @@ public class TenantApiController {
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes all tenant metadata for an account")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Successfully removed tenant metadata")})
-  @JsonView(View.Admin.class)
   public void delete(@PathVariable String tenantId) {
     tenantManagement.removeTenantMetadata(tenantId);
   }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataDTO.java
@@ -18,7 +18,7 @@ package com.rackspace.salus.policy.manage.web.model;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
-import com.rackspace.salus.telemetry.model.View;
+import com.rackspace.salus.common.web.View;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.UUID;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,15 @@ salus:
   services:
     resourceManagementUrl: http://localhost:8085
     monitorManagementUrl: http://localhost:8089
+  common:
+    roles:
+      role-to-view:
+        # An anonymous role is used for unauthenticated requests.
+        # i.e. internal service-to-service requests.
+        ROLE_ANONYMOUS: ADMIN
+        ROLE_CUSTOMER: PUBLIC
+        ROLE_EMPLOYEE: INTERNAL
+        ROLE_ENGINEER: ADMIN
 spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect

--- a/src/test/resources/TenantApiControllerTest/basic_tenant_metadata.json
+++ b/src/test/resources/TenantApiControllerTest/basic_tenant_metadata.json
@@ -1,5 +1,6 @@
 {
   "id": "09867b47-2da6-4100-9366-8facf499285a",
+  "tenantId": "MyTenantId",
   "accountType": "MyAccountType",
   "metadata": {
     "dummy": "value"


### PR DESCRIPTION
# What

Enable role based json views instead of endpoint driven views.

# How

1. Add `@EnableRoleBasedJsonViews` to app
   * https://github.com/racker/salus-common/pull/49
1. Remove `@JsonView` annotations on api controllers
1. Add default role mappings to `application-dev.yml`

# Why

See https://github.com/racker/salus-common/pull/49
