### PR TITLE
Added caching of the PolicyApiClient calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,18 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.ehcache</groupId>
+      <artifactId>ehcache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -16,9 +16,7 @@
 
 package com.rackspace.salus.policy.manage.web.client;
 
-import com.rackspace.salus.policy.manage.web.model.MetadataPolicyDTO;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
-import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.util.List;
@@ -32,8 +30,8 @@ import java.util.UUID;
  * @see PolicyApiClient
  */
 public interface PolicyApi {
-  List<MonitorPolicyDTO> getEffectiveMonitorPolicies(String tenantId);
-  List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId);
-  List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId);
-  Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(String tenantId, TargetClassName className, MonitorType monitorType);
+  List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache);
+  List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId, boolean useCache);
+  Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
+      String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache);
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.client;
+
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the caches used by {@link PolicyApiClient}, so any use of that component should also
+ * <code>&#64;Import</code> this config bean.
+ */
+@Configuration
+@EnableConfigurationProperties(PolicyApiCacheProperties.class)
+@EnableCaching
+public class PolicyApiCacheConfig {
+
+  private final PolicyApiCacheProperties properties;
+
+  @Autowired
+  public PolicyApiCacheConfig(PolicyApiCacheProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public JCacheManagerCustomizer policyManagementCacheCustomizer() {
+    return cacheManager -> {
+      cacheManager.createCache("policymgmt_monitor_policies", policiesCacheConfig());
+      cacheManager.createCache("policymgmt_policy_monitor_ids", policiesCacheConfig());
+      cacheManager.createCache("policymgmt_monitor_metadata_policies", metadataCacheConfig());
+      cacheManager.createCache("policymgmt_monitor_metadata_map", metadataCacheConfig());
+    };
+  }
+
+  private javax.cache.configuration.Configuration<Object, Object> policiesCacheConfig() {
+    return Eh107Configuration.fromEhcacheCacheConfiguration(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
+            ResourcePoolsBuilder.heap(properties.getPoliciesMaxSize())
+        )
+        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
+    );
+  }
+
+  private javax.cache.configuration.Configuration<Object, Object> metadataCacheConfig() {
+    return Eh107Configuration.fromEhcacheCacheConfiguration(
+        CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
+            ResourcePoolsBuilder.heap(properties.getMetadataMaxSize())
+        )
+        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(properties.getTtl()))
+    );
+  }
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheProperties.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheProperties.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.client;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
+
+@Data
+@ConfigurationProperties("salus.policymgmt.cache")
+public class PolicyApiCacheProperties {
+
+  /**
+   * Maximum cache size of policy references.
+   */
+  long policiesMaxSize = 10_000;
+
+  /**
+   * Maximum cache size of policy metadata collections.
+   */
+  long metadataMaxSize = 10_000;
+
+  /**
+   * Duration to expire cache entries after creation.
+   */
+  @DurationUnit(ChronoUnit.MINUTES)
+  Duration ttl = Duration.ofMinutes(5);
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -69,9 +69,9 @@ public class PolicyApiClient implements PolicyApi {
   }
 
   @CacheEvict(cacheNames = "policymgmt_policy_monitor_ids", key = "#tenantId",
-      condition = "#useCache != null && !#useCache", beforeInvocation = true)
+      condition = "!#useCache", beforeInvocation = true)
   @Cacheable(cacheNames = "policymgmt_policy_monitor_ids", key = "#tenantId",
-      condition = "#useCache == null || #useCache")
+      condition = "#useCache")
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}/ids")
@@ -87,9 +87,9 @@ public class PolicyApiClient implements PolicyApi {
   }
 
   @CacheEvict(cacheNames = "policymgmt_monitor_metadata_policies", key = "#tenantId",
-      condition = "#useCache != null && !#useCache", beforeInvocation = true)
+      condition = "!#useCache", beforeInvocation = true)
   @Cacheable(cacheNames = "policymgmt_monitor_metadata_policies", key = "#tenantId",
-      condition = "#useCache == null || #useCache")
+      condition = "#useCache")
   public List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(
       String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
@@ -106,9 +106,9 @@ public class PolicyApiClient implements PolicyApi {
   }
 
   @CacheEvict(cacheNames = "policymgmt_monitor_metadata_map", key = "{#tenantId, #className, #monitorType}",
-      condition = "#useCache != null && !#useCache", beforeInvocation = true)
+      condition = "!#useCache", beforeInvocation = true)
   @Cacheable(cacheNames = "policymgmt_monitor_metadata_map", key = "{#tenantId, #className, #monitorType}",
-      condition = "#useCache == null || #useCache")
+      condition = "#useCache")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
     final String uri = UriComponentsBuilder

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
@@ -55,7 +56,10 @@ import org.springframework.web.util.UriComponentsBuilder;
     }
   }
  * </pre>
- *
+ * <p>
+ *   This component declares the option to cache the results of each operation. To enable caching
+ *   <code>&#64;Import</code> {@link PolicyApiCacheConfig} on a config bean declaring the client bean.
+ * </p>
  */
 public class PolicyApiClient implements PolicyApi {
   private static final ParameterizedTypeReference<List<MonitorPolicyDTO>> LIST_OF_MONITOR_POLICY = new ParameterizedTypeReference<>() {};
@@ -68,6 +72,7 @@ public class PolicyApiClient implements PolicyApi {
     this.restTemplate = restTemplate;
   }
 
+  @Cacheable("policymgmt_monitor_policies")
   public List<MonitorPolicyDTO> getEffectiveMonitorPolicies(String tenantId) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}")
@@ -82,6 +87,7 @@ public class PolicyApiClient implements PolicyApi {
     ).getBody();
   }
 
+  @Cacheable("policymgmt_policy_monitor_ids")
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}/ids")
@@ -96,6 +102,7 @@ public class PolicyApiClient implements PolicyApi {
     ).getBody();
   }
 
+  @Cacheable("policymgmt_monitor_metadata_policies")
   public List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}")
@@ -110,6 +117,7 @@ public class PolicyApiClient implements PolicyApi {
     ).getBody();
   }
 
+  @Cacheable("policymgmt_monitor_metadata_map")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(String tenantId, TargetClassName className, MonitorType monitorType) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.client;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.MonitorType;
+import com.rackspace.salus.telemetry.model.TargetClassName;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+
+@RunWith(SpringRunner.class)
+@RestClientTest
+public class PolicyApiClientTest {
+
+  @TestConfiguration
+  public static class ExtraTestConfig {
+    @Bean
+    public PolicyApiClient policyApiClient(RestTemplateBuilder restTemplateBuilder) {
+      return new PolicyApiClient(restTemplateBuilder.build());
+    }
+  }
+  @Autowired
+  MockRestServiceServer mockServer;
+
+  @Autowired
+  PolicyApiClient policyApiClient;
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testGetEffectiveMonitorMetadataMapWithCache() throws JsonProcessingException {
+    Map<String, MonitorMetadataPolicyDTO> expectedPolicy = Map.of(
+        "count", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+            .setKey("count")
+            .setValueType(MetadataValueType.INT)
+            .setValue("63"),
+        "pingInterval", (MonitorMetadataPolicyDTO) new MonitorMetadataPolicyDTO()
+            .setKey("pingInterval")
+            .setValueType(MetadataValueType.DURATION)
+            .setValue("PT2S"));
+
+    String tenantId = RandomStringUtils.randomAlphanumeric(10);
+
+    mockServer.expect(ExpectedCount.once(),
+        requestTo(String.format(
+            "/api/admin/policy/metadata/monitor/effective/%s/RemotePlugin/ping", tenantId)))
+        .andRespond(withSuccess(
+            objectMapper.writeValueAsString(expectedPolicy), MediaType.APPLICATION_JSON
+        ));
+
+    Map<String, MonitorMetadataPolicyDTO> policies = policyApiClient.getEffectiveMonitorMetadataMap(
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+
+    assertThat(policies, equalTo(expectedPolicy));
+
+    // running the same request again should trigger bypass the cache and perform a full request
+    policies = policyApiClient.getEffectiveMonitorMetadataMap(
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+
+    assertThat(policies, equalTo(expectedPolicy));
+    mockServer.verify();
+  }
+
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -146,8 +146,6 @@ public class PolicyApiClientTest {
         tenantId, TargetClassName.RemotePlugin, MonitorType.ping, false);
 
     assertThat(policies, equalTo(expectedPolicy));
-
-    assertThat(policies, equalTo(expectedPolicy));
     mockServer.verify();
   }
 


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-731

# What

From issue description:

Things like monitor management have to request data from policy management, but that data will change infrequently.

These responses should be cached so if policy mgmt it does not cause many problems and so that general api requests can be faster.

# How

Introduce Spring Caching on the PolicyApiClient methods since that is what gets invoked by the applications, such as monitor management, to query policies and metadata.

# How to test

Existing unit tests

# Why

Originally I attempted the caching with Caffeine. It worked, but was somewhat tedious to configure the potentially different entry limits and TTL per cache. Since it was going to be tedious anyway, I thought I would explore the use of ehcache instead. That caching technology is much more mature, configurable, and flexible in general and was just as easy, if not easier, to configure.