### PR TITLE
Fix cloudbuild.

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -4,7 +4,6 @@ substitutions:
   _SALUS_APP: policy-management
   _APP_NAMESPACE: salus-development
   _CLOUDSDK_COMPUTE_ZONE: us-east1-b
-  _CLOUDSDK_COMPUTE_REGION: us-east1
   _CLOUDSDK_CONTAINER_CLUSTER: salus-dev
 
 steps:
@@ -102,6 +101,7 @@ steps:
     - PUSH_UP_CACHE
     args: ['clone', 'https://source.developers.google.com/p/$PROJECT_ID/r/github_rackspace-segment-support_helm-salus-${_SALUS_APP}', '/workspace/helm-salus-${_SALUS_APP}/']
 
+  # Set _CLOUDSDK_COMPUTE_REGION in the build trigger for non-dev clusters
   - name: 'gcr.io/$PROJECT_ID/helm'
     id: DEPLOY_APPLICATION
     args: ['upgrade', '--install', '${_SALUS_APP}', '--namespace', '${_APP_NAMESPACE}', '/workspace/helm-salus-${_SALUS_APP}']
@@ -110,3 +110,6 @@ steps:
     - 'CLOUDSDK_COMPUTE_REGION=${_CLOUDSDK_COMPUTE_REGION}'
     - 'CLOUDSDK_CONTAINER_CLUSTER=${_CLOUDSDK_CONTAINER_CLUSTER}'
     - 'TILLERLESS=true'
+
+options:
+    substitution_option: 'ALLOW_LOOSE'


### PR DESCRIPTION
Allowing loose substitution lets you not specify a substitution in the yaml file so that it can instead be used later in a build trigger. 