### PR TITLE
Update monitor policy operations

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/services/EventListener.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/EventListener.java
@@ -17,7 +17,6 @@
 package com.rackspace.salus.policy.manage.services;
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
-import com.rackspace.salus.telemetry.messaging.PolicyMonitorUpdateEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -46,14 +45,6 @@ public class EventListener {
    */
   public String getTopic() {
     return this.topic;
-  }
-
-  @KafkaHandler
-  public void consumePolicyMonitorUpdateEvents(PolicyMonitorUpdateEvent updateEvent) {
-    // Ignore non-null tenant events.  These will be handled by monitor management.
-    if (updateEvent.getTenantId() == null) {
-      monitorPolicyManagement.handlePolicyMonitorUpdate(updateEvent.getMonitorId());
-    }
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagement.java
@@ -109,11 +109,12 @@ public class MonitorPolicyManagement {
     policy.setScope(scope);
     policy.setSubscope(subscope);
 
-    Set<String> allUniqueTenants = new HashSet<>(policyManagement.getTenantsForPolicy(policy));
-    allUniqueTenants.addAll(originalTenants);
+    // gets the tenants for the updated policy and then creates a union with the original tenants
+    Set<String> allRelevantTenants = new HashSet<>(policyManagement.getTenantsForPolicy(policy));
+    allRelevantTenants.addAll(originalTenants);
 
     monitorPolicyRepository.save(policy);
-    sendMonitorPolicyEventsForTenants(policy, allUniqueTenants);
+    sendMonitorPolicyEventsForTenants(policy, allRelevantTenants);
 
     return policy;
   }
@@ -236,6 +237,10 @@ public class MonitorPolicyManagement {
 
   /**
    * Verifies the scope values provided are allowed.
+   *
+   * A global scope cannot have a subscope (by design global means it affects all tenants).
+   * A non-global scope must have a subscope specified to identify the subset of accounts impacted.
+   *
    * @param scope The scope of the policy.
    * @param subscope The subscope of the policy.
    * @throws IllegalArgumentException If an invalid combination of the two fields is used.

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorPolicyManagement.java
@@ -18,7 +18,7 @@ package com.rackspace.salus.policy.manage.services;
 
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyUpdate;
-import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
+import com.rackspace.salus.policy.manage.web.model.validator.ValidNewPolicy;
 import com.rackspace.salus.telemetry.entities.Monitor;
 import com.rackspace.salus.telemetry.entities.MonitorPolicy;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
@@ -248,7 +248,7 @@ public class MonitorPolicyManagement {
   private void validateScope(PolicyScope scope, String subscope) throws IllegalArgumentException {
     if ((scope.equals(PolicyScope.GLOBAL) && subscope != null) ||
         (!scope.equals(PolicyScope.GLOBAL) && subscope == null)) {
-      throw new IllegalArgumentException(ValidPolicy.DEFAULT_MESSAGE);
+      throw new IllegalArgumentException(ValidNewPolicy.DEFAULT_MESSAGE);
     }
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyEventProducer.java
@@ -20,7 +20,6 @@ import static com.rackspace.salus.telemetry.messaging.KafkaMessageKeyBuilder.bui
 
 import com.rackspace.salus.common.messaging.KafkaTopicProperties;
 import com.rackspace.salus.telemetry.messaging.PolicyEvent;
-import com.rackspace.salus.telemetry.messaging.PolicyMonitorUpdateEvent;
 import com.rackspace.salus.telemetry.messaging.TenantPolicyChangeEvent;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,13 +43,6 @@ public class PolicyEventProducer {
     final String topic = properties.getPolicies();
 
     log.debug("Sending policyEvent={} on topic={}", event, topic);
-    kafkaTemplate.send(topic, buildMessageKey(event), event);
-  }
-
-  void sendPolicyMonitorUpdateEvent(PolicyMonitorUpdateEvent event) {
-    final String topic = properties.getPolicies();
-
-    log.debug("Sending policyMonitorUpdateEvent={} on topic={}", event, topic);
     kafkaTemplate.send(topic, buildMessageKey(event), event);
   }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -30,6 +30,7 @@ import java.util.UUID;
  * @see PolicyApiClient
  */
 public interface PolicyApi {
+  List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean useCache);
   List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache);
   List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId, boolean useCache);
   Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
@@ -47,6 +47,7 @@ public class PolicyApiCacheConfig {
   public JCacheManagerCustomizer policyManagementCacheCustomizer() {
     return cacheManager -> {
       cacheManager.createCache("policymgmt_monitor_policies", policiesCacheConfig());
+      cacheManager.createCache("policymgmt_monitor_policy_ids", policiesCacheConfig());
       cacheManager.createCache("policymgmt_policy_monitor_ids", policiesCacheConfig());
       cacheManager.createCache("policymgmt_monitor_metadata_policies", metadataCacheConfig());
       cacheManager.createCache("policymgmt_monitor_metadata_map", metadataCacheConfig());

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -68,13 +68,31 @@ public class PolicyApiClient implements PolicyApi {
     this.restTemplate = restTemplate;
   }
 
+  @CacheEvict(cacheNames = "policymgmt_monitor_policy_ids", key = "#tenantId",
+      condition = "!#useCache", beforeInvocation = true)
+  @Cacheable(cacheNames = "policymgmt_monitor_policy_ids", key = "#tenantId",
+      condition = "#useCache")
+  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean useCache) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/admin/policy/monitors/effective/{tenantId}/policy-ids")
+        .build(tenantId)
+        .toString();
+
+    return restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        LIST_OF_UUID
+    ).getBody();
+  }
+
   @CacheEvict(cacheNames = "policymgmt_policy_monitor_ids", key = "#tenantId",
       condition = "!#useCache", beforeInvocation = true)
   @Cacheable(cacheNames = "policymgmt_policy_monitor_ids", key = "#tenantId",
       condition = "#useCache")
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
-        .fromPath("/api/admin/policy/monitors/effective/{tenantId}/ids")
+        .fromPath("/api/admin/policy/monitors/effective/{tenantId}/monitor-ids")
         .build(tenantId)
         .toString();
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
@@ -19,6 +19,7 @@ package com.rackspace.salus.policy.manage.web.controller;
 import com.rackspace.salus.policy.manage.services.MonitorPolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.MonitorPolicyUpdate;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
 import io.swagger.annotations.ApiOperation;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -71,11 +73,18 @@ public class MonitorPolicyApiController {
         .stream().map(MonitorPolicyDTO::new).collect(Collectors.toList());
   }
 
-  @GetMapping("/admin/policy/monitors/effective/{tenantId}/ids")
+  @GetMapping("/admin/policy/monitors/effective/{tenantId}/monitor-ids")
   @ApiOperation(value = "Gets effective policy monitor ids by tenant id")
-  @ApiResponses(value = { @ApiResponse(code = 200, message = "Monitor policy ids retrieved")})
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Policy Monitor ids retrieved")})
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(@PathVariable String tenantId) {
     return monitorPolicyManagement.getEffectivePolicyMonitorIdsForTenant(tenantId);
+  }
+
+  @GetMapping("/admin/policy/monitors/effective/{tenantId}/policy-ids")
+  @ApiOperation(value = "Gets effective policy monitor ids by tenant id")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Monitor Policy ids retrieved")})
+  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(@PathVariable String tenantId) {
+    return monitorPolicyManagement.getEffectiveMonitorPolicyIdsForTenant(tenantId);
   }
 
   @GetMapping("/admin/policy/monitors")
@@ -86,9 +95,17 @@ public class MonitorPolicyApiController {
         .map(MonitorPolicyDTO::new));
   }
 
+  @PutMapping("/admin/policy/monitors/{uuid}")
+  @ApiOperation(value = "Updates the scope of an existing monitor policy")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully updated Monitor Policy")})
+  public MonitorPolicyDTO update(@PathVariable UUID uuid, @RequestBody final MonitorPolicyUpdate input)
+      throws IllegalArgumentException {
+    return new MonitorPolicyDTO(monitorPolicyManagement.updateMonitorPolicy(uuid, input));
+  }
+
   @PostMapping("/admin/policy/monitors")
   @ResponseStatus(HttpStatus.CREATED)
-  @ApiOperation(value = "Creates new Monitor for Tenant")
+  @ApiOperation(value = "Creates new Monitor Policy")
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Monitor Policy")})
   public MonitorPolicyDTO create(@Valid @RequestBody final MonitorPolicyCreate input)
       throws IllegalArgumentException {

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyUpdate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyUpdate.java
@@ -17,27 +17,16 @@
 package com.rackspace.salus.policy.manage.web.model;
 
 import com.rackspace.salus.telemetry.model.PolicyScope;
-import com.rackspace.salus.policy.manage.web.model.validator.ValidPolicy;
 import java.io.Serializable;
-import java.util.UUID;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
-import org.hibernate.validator.constraints.NotBlank;
 
 /**
- * This Object is used for handling the creation of Monitor Policies.
+ * This Object is used for handling the updating of Monitor Policies.
  */
 @Data
-@ValidPolicy
-public class MonitorPolicyCreate implements Serializable {
-  @NotNull
+public class MonitorPolicyUpdate implements Serializable {
+
   PolicyScope scope;
 
   String subscope;
-
-  @NotBlank
-  String name;
-
-  @NotNull
-  UUID monitorId;
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/ValidPolicy.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/ValidPolicy.java
@@ -33,7 +33,8 @@ import javax.validation.Payload;
 @Constraint(validatedBy = {MonitorPolicyCreateValidator.class, MetadataPolicyCreateValidator.class})
 public @interface ValidPolicy {
 
-  String message() default "subscope must be set for any non-global policy but not for global policies";
+  String DEFAULT_MESSAGE = "subscope must be set for any non-global policy but not for global policies";
+  String message() default DEFAULT_MESSAGE;
 
   Class<?>[] groups() default {};
 

--- a/src/test/java/com/rackspace/salus/policy/manage/TestUtility.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/TestUtility.java
@@ -44,7 +44,11 @@ public class TestUtility {
   }
 
   public static List<String> createMultipleTenants(ResourceRepository resourceRepository) {
-    return IntStream.range(0, 5)
+    return createMultipleTenants(resourceRepository, 5);
+  }
+
+  public static List<String> createMultipleTenants(ResourceRepository resourceRepository, int count) {
+    return IntStream.range(0, count)
         .mapToObj(i -> createSingleTenant(resourceRepository))
         .collect(Collectors.toList());
   }


### PR DESCRIPTION
# What

Adds methods to update monitor policies.
Adds a few other api methods to allow for the changes in https://github.com/racker/salus-telemetry-monitor-management/pull/162

# How

Only the scope of a policy can be updated.  It will trigger a kafka event that monitor management will consume to determine if any policy monitor needs to be cloned to or removed from the customer tenant.

More info on this will be added to https://github.com/racker/salus-docs - for now see the internal docs repo which documents the proposal for this.