### PR TITLE
Add zone metadata

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
@@ -325,7 +325,11 @@ public class MonitorMetadataPolicyManagement {
    */
   private List<String> getTenantsForMetadataPolicy(MonitorMetadataPolicy policy) {
     List<String> tenantsUsingPolicyKey;
-    if (policy.getTargetClassName().equals(TargetClassName.Monitor)) {
+    if (policy.getKey().startsWith(MetadataPolicy.ZONE_METADATA_PREFIX)) {
+      tenantsUsingPolicyKey = entityManager
+          .createNamedQuery("Monitor.getTenantsUsingZoneMetadata", String.class)
+          .getResultList();
+    } else if (policy.getTargetClassName().equals(TargetClassName.Monitor)) {
       tenantsUsingPolicyKey = entityManager
           .createNamedQuery("Monitor.getTenantsUsingPolicyMetadataInMonitor", String.class)
           .setParameter("metadataKey", policy.getKey())

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -35,4 +35,5 @@ public interface PolicyApi {
   List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId, boolean useCache);
   Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache);
+  List<String> getDefaultMonitoringZones(String region, boolean useCache);
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiCacheConfig.java
@@ -51,6 +51,7 @@ public class PolicyApiCacheConfig {
       cacheManager.createCache("policymgmt_policy_monitor_ids", policiesCacheConfig());
       cacheManager.createCache("policymgmt_monitor_metadata_policies", metadataCacheConfig());
       cacheManager.createCache("policymgmt_monitor_metadata_map", metadataCacheConfig());
+      cacheManager.createCache("policymgmt_zone_metadata", metadataCacheConfig());
     };
   }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -61,6 +61,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class PolicyApiClient implements PolicyApi {
   private static final ParameterizedTypeReference<List<MonitorMetadataPolicyDTO>> LIST_OF_MONITOR_METADATA_POLICY = new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<List<UUID>> LIST_OF_UUID = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<List<String>> LIST_OF_STRING = new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<Map<String, MonitorMetadataPolicyDTO>> MAP_OF_MONITOR_POLICY = new ParameterizedTypeReference<>() {};
   private final RestTemplate restTemplate;
 
@@ -139,6 +140,23 @@ public class PolicyApiClient implements PolicyApi {
         HttpMethod.GET,
         null,
         MAP_OF_MONITOR_POLICY
+    ).getBody();
+  }
+
+  @CacheEvict(cacheNames = "policymgmt_zone_metadata", key = "#region", condition = "!#useCache",
+      beforeInvocation = true)
+  @Cacheable(cacheNames = "policymgmt_zone_metadata", key = "#region", condition = "#useCache")
+  public List<String> getDefaultMonitoringZones(String region, boolean useCache) {
+    final String uri = UriComponentsBuilder
+        .fromPath("/api/admin/policy/metadata/zones/{region}")
+        .build(region)
+        .toString();
+
+    return restTemplate.exchange(
+        uri,
+        HttpMethod.GET,
+        null,
+        LIST_OF_STRING
     ).getBody();
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -20,6 +20,7 @@ import com.rackspace.salus.policy.manage.services.MonitorMetadataPolicyManagemen
 import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
+import com.rackspace.salus.policy.manage.web.model.ZoneMetadataPolicyCreate;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
@@ -99,6 +100,13 @@ public class MetadataPolicyApiController {
         .map(MonitorMetadataPolicyDTO::new));
   }
 
+  @GetMapping("/admin/policy/metadata/zones/{region}")
+  @ApiOperation(value = "Gets default monitoring zones for a region")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Zones Retrieved")})
+  public List<String> getDefaultMonitoringZones(@PathVariable String region) {
+    return monitorMetadataPolicyManagement.getDefaultMonitoringZones(region);
+  }
+
   @PostMapping("/admin/policy/metadata/monitor")
   @ResponseStatus(HttpStatus.CREATED)
   @ApiOperation(value = "Creates new monitor metadata Policy")
@@ -106,6 +114,15 @@ public class MetadataPolicyApiController {
   public MonitorMetadataPolicyDTO createMonitorMetadata(@Valid @RequestBody final MonitorMetadataPolicyCreate input)
       throws IllegalArgumentException {
     return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createMetadataPolicy(input));
+  }
+
+  @PostMapping("/admin/policy/metadata/zones")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates new zone metadata Policy")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Metadata Policy")})
+  public MonitorMetadataPolicyDTO createZoneMetadata(@Valid @RequestBody final ZoneMetadataPolicyCreate input)
+      throws IllegalArgumentException {
+    return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createZonePolicy(input));
   }
 
   @PutMapping("/admin/policy/metadata/monitor/{uuid}")

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiController.java
@@ -21,6 +21,7 @@ import com.rackspace.salus.policy.manage.web.model.MetadataPolicyUpdate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
 import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.policy.manage.web.model.ZoneMetadataPolicyCreate;
+import com.rackspace.salus.policy.manage.web.model.ZoneMetadataPolicyUpdate;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.NotFoundException;
 import com.rackspace.salus.telemetry.model.PagedContent;
@@ -122,7 +123,8 @@ public class MetadataPolicyApiController {
   @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully Created Metadata Policy")})
   public MonitorMetadataPolicyDTO createZoneMetadata(@Valid @RequestBody final ZoneMetadataPolicyCreate input)
       throws IllegalArgumentException {
-    return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createZonePolicy(input));
+    return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.createZonePolicy(
+        input.getRegion(), input.getMonitoringZones()));
   }
 
   @PutMapping("/admin/policy/metadata/monitor/{uuid}")
@@ -133,11 +135,28 @@ public class MetadataPolicyApiController {
     return new MonitorMetadataPolicyDTO(monitorMetadataPolicyManagement.updateMetadataPolicy(uuid, input));
   }
 
+  @PutMapping("/admin/policy/metadata/zones/{region}")
+  @ApiOperation(value = "Updates the default monitoring zones for a region")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Zones Retrieved")})
+  public MonitorMetadataPolicyDTO updateZoneMetadata(@PathVariable String region, @Valid @RequestBody
+      ZoneMetadataPolicyUpdate update) {
+    return new MonitorMetadataPolicyDTO(
+        monitorMetadataPolicyManagement.updateZonePolicy(region, update.getMonitoringZones()));
+  }
+
   @DeleteMapping("/admin/policy/metadata/monitor/{uuid}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes specific Metadata Policy")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Metadata Policy Deleted")})
   public void delete(@PathVariable UUID uuid) {
     monitorMetadataPolicyManagement.removeMetadataPolicy(uuid);
+  }
+
+  @DeleteMapping("/admin/policy/metadata/zones/{region}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @ApiOperation(value = "Deletes specific Zone Policy")
+  @ApiResponses(value = { @ApiResponse(code = 204, message = "Zone Policy Deleted")})
+  public void delete(@PathVariable String region) {
+    monitorMetadataPolicyManagement.removeZonePolicy(region);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/ZoneMetadataPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/ZoneMetadataPolicyCreate.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class ZoneMetadataPolicyCreate {
+  @NotBlank
+  String region;
+
+  @NotEmpty
+  List<String> monitoringZones;
+}

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/ZoneMetadataPolicyUpdate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/ZoneMetadataPolicyUpdate.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.model;
+
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class ZoneMetadataPolicyUpdate {
+  @NotEmpty
+  List<String> monitoringZones;
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.rackspace.salus.policy.manage.TestUtility;
 import com.rackspace.salus.policy.manage.config.DatabaseConfig;
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
@@ -126,7 +125,7 @@ public class MonitorMetadataPolicyManagementTest_Zones {
 
   @Test
   public void testCreateZonePolicy() {
-    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String tenantId = randomAlphabetic(5);
     String region = randomAlphabetic(5);
     List<String> zones = List.of(randomAlphabetic(5), randomAlphabetic(5));
 
@@ -154,7 +153,7 @@ public class MonitorMetadataPolicyManagementTest_Zones {
 
   @Test
   public void testUpdateZonePolicy() {
-    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String tenantId = randomAlphabetic(5);
     String region = randomAlphabetic(5);
     List<String> newZones = List.of(randomAlphabetic(5), randomAlphabetic(5));
 
@@ -178,7 +177,7 @@ public class MonitorMetadataPolicyManagementTest_Zones {
 
   @Test
   public void testRemoveZonePolicy() {
-    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String tenantId = randomAlphabetic(5);
     String region = randomAlphabetic(5);
 
     // Create a policy to remove

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.services;
+
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.rackspace.salus.policy.manage.TestUtility;
+import com.rackspace.salus.policy.manage.config.DatabaseConfig;
+import com.rackspace.salus.telemetry.entities.MetadataPolicy;
+import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
+import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
+import com.rackspace.salus.telemetry.messaging.PolicyEvent;
+import com.rackspace.salus.telemetry.model.MetadataValueType;
+import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.model.TargetClassName;
+import com.rackspace.salus.telemetry.repositories.MonitorMetadataPolicyRepository;
+import com.rackspace.salus.telemetry.repositories.MonitorRepository;
+import com.rackspace.salus.telemetry.repositories.PolicyRepository;
+import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import com.rackspace.salus.test.EnableTestContainersDatabase;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.TypedQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.co.jemos.podam.api.PodamFactory;
+import uk.co.jemos.podam.api.PodamFactoryImpl;
+
+@RunWith(SpringRunner.class)
+@EnableTestContainersDatabase
+@DataJpaTest(showSql = false)
+@Import({PolicyManagement.class, MonitorMetadataPolicyManagement.class,
+    TenantManagement.class, DatabaseConfig.class})
+public class MonitorMetadataPolicyManagementTest_Zones {
+
+  private PodamFactory podamFactory = new PodamFactoryImpl();
+
+  @Captor
+  ArgumentCaptor<PolicyEvent> policyEventArg;
+
+  @MockBean
+  PolicyEventProducer policyEventProducer;
+
+  @Autowired
+  PolicyManagement policyManagement;
+
+  @Autowired
+  MonitorMetadataPolicyManagement monitorMetadataPolicyManagement;
+
+  @Autowired
+  TenantManagement tenantManagement;
+
+  @Autowired
+  PolicyRepository policyRepository;
+
+  @Autowired
+  MonitorMetadataPolicyRepository monitorMetadataPolicyRepository;
+
+  @Autowired
+  TenantMetadataRepository tenantMetadataRepository;
+
+  @Autowired
+  ResourceRepository resourceRepository;
+
+  @Autowired
+  MonitorRepository monitorRepository;
+
+  @MockBean
+  EntityManager entityManager;
+
+  @Mock
+  TypedQuery query;
+
+  @Before
+  public void setup() {
+    List<String> defaultZones = List.of("zone-1", "zone-2");
+    MonitorMetadataPolicy policy = (MonitorMetadataPolicy) new MonitorMetadataPolicy()
+        .setValue(String.join(",", defaultZones))
+        .setKey(MetadataPolicy.ZONE_METADATA_PREFIX + MetadataPolicy.DEFAULT_ZONE)
+        .setValueType(MetadataValueType.STRING_LIST)
+        .setTargetClassName(TargetClassName.RemotePlugin)
+        .setSubscope(null)
+        .setScope(PolicyScope.GLOBAL);
+
+    monitorMetadataPolicyRepository.save(policy);
+  }
+
+  @Test
+  public void testGetDefaultMonitoringZones() {
+    List<String> zones = monitorMetadataPolicyManagement.getDefaultMonitoringZones(MetadataPolicy.DEFAULT_ZONE);
+    assertThat(zones, equalTo(List.of("zone-1", "zone-2")));
+  }
+
+  @Test
+  public void testCreateZonePolicy() {
+    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String region = randomAlphabetic(5);
+    List<String> zones = List.of(randomAlphabetic(5), randomAlphabetic(5));
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    MonitorMetadataPolicy policy = monitorMetadataPolicyManagement.createZonePolicy(region, zones);
+    assertThat(policy.getId(), notNullValue());
+    assertThat(policy.getScope(), equalTo(PolicyScope.GLOBAL));
+    assertThat(policy.getSubscope(), nullValue());
+    assertThat(policy.getMonitorType(), nullValue());
+    assertThat(policy.getValueType(), equalTo(MetadataValueType.STRING_LIST));
+    assertThat(policy.getKey(), equalTo(MetadataPolicy.ZONE_METADATA_PREFIX + region));
+    assertThat(policy.getValue(), equalTo(String.join(",", zones)));
+
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId)
+    ));
+
+    verifyNoMoreInteractions(policyEventProducer);
+  }
+
+  @Test
+  public void testUpdateZonePolicy() {
+    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String region = randomAlphabetic(5);
+    List<String> newZones = List.of(randomAlphabetic(5), randomAlphabetic(5));
+
+    MetadataPolicy policy = saveZonePolicy(region);
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    MonitorMetadataPolicy updatedPolicy = monitorMetadataPolicyManagement.updateZonePolicy(region, newZones);
+
+    assertThat(updatedPolicy.getId(), equalTo(policy.getId()));
+    assertThat(updatedPolicy.getKey(), equalTo(MetadataPolicy.ZONE_METADATA_PREFIX + region));
+    assertThat(updatedPolicy.getValue(), equalTo(String.join(",", newZones)));
+
+    verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
+    assertThat(policyEventArg.getValue(), equalTo(
+        new MetadataPolicyEvent()
+            .setPolicyId(policy.getId())
+            .setTenantId(tenantId)
+    ));
+  }
+
+  @Test
+  public void testRemoveZonePolicy() {
+    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String region = randomAlphabetic(5);
+
+    // Create a policy to remove
+    MetadataPolicy policy = saveZonePolicy(region);
+
+    mockGetTenantsUsingPolicyKey(List.of(tenantId));
+
+    monitorMetadataPolicyManagement.removeZonePolicy(region);
+    List<String> afterRemove = monitorMetadataPolicyManagement.getDefaultMonitoringZones(region);
+    assertThat(afterRemove, hasSize(0));
+
+    // a zone removal does not trigger any monitors to be rebound
+    verifyNoInteractions(policyEventProducer);
+  }
+
+  @Test
+  public void testRemoveZonePolicy_doesntExist() {
+    String region = randomAlphabetic(5);
+    assertThatThrownBy(() -> monitorMetadataPolicyManagement.removeZonePolicy(region))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessage(
+            String.format("No zone policy found for region %s", region)
+        );
+  }
+
+  private void mockGetTenantsUsingPolicyKey(List<String> tenantIds) {
+    when(entityManager.createNamedQuery(anyString(), any())).thenReturn(query);
+    when(query.setParameter(anyString(), any())).thenReturn(query);
+    when(query.getResultList()).thenReturn(tenantIds);
+  }
+
+  private MetadataPolicy saveZonePolicy(String region) {
+    List<String> zones = List.of(randomAlphabetic(5), randomAlphabetic(5));
+    return (MetadataPolicy) policyRepository.save(new MonitorMetadataPolicy()
+        .setValue(String.join(",", zones))
+        .setKey(MetadataPolicy.ZONE_METADATA_PREFIX + region)
+        .setTargetClassName(TargetClassName.RemotePlugin)
+        .setValueType(MetadataValueType.STRING_LIST)
+        .setScope(PolicyScope.GLOBAL));
+  }
+}

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
@@ -60,8 +60,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
-import uk.co.jemos.podam.api.PodamFactory;
-import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 @RunWith(SpringRunner.class)
 @EnableTestContainersDatabase
@@ -69,8 +67,6 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 @Import({PolicyManagement.class, MonitorMetadataPolicyManagement.class,
     TenantManagement.class, DatabaseConfig.class})
 public class MonitorMetadataPolicyManagementTest_Zones {
-
-  private PodamFactory podamFactory = new PodamFactoryImpl();
 
   @Captor
   ArgumentCaptor<PolicyEvent> policyEventArg;


### PR DESCRIPTION
# What

Helper methods to allow for the storage and querying of zone metadata.

# How

Adds new endpoints to simplify the creation of monitoring zone metadata but it still utilizes the same logic as monitor metadata and is stored in the same database using `monitorMetadataPolicyRepository`.

This allows us to limit the flexibility of zone metadata and keep it simple until we know we have to allow for more.  i.e. for now we hardcode values for many fields

# Why

Allows new monitors to be created without setting the `zone` field.  The zone will then be set at resource binding based on the `region` of each individual resource.

Relates to https://github.com/racker/salus-telemetry-monitor-management/pull/164