### PR TITLE
Enable tenant id verification

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/PolicyManagementApplication.java
@@ -17,9 +17,10 @@
 package com.rackspace.salus.policy.manage;
 
 import com.rackspace.salus.common.messaging.EnableSalusKafkaMessaging;
-import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.util.DumpConfigProperties;
+import com.rackspace.salus.common.web.EnableExtendedErrorAttributes;
 import com.rackspace.salus.common.web.EnableRoleBasedJsonViews;
+import com.rackspace.salus.telemetry.web.EnableTenantVerification;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -27,6 +28,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @EnableSalusKafkaMessaging
 @EnableExtendedErrorAttributes
 @EnableRoleBasedJsonViews
+@EnableTenantVerification
 public class PolicyManagementApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/rackspace/salus/policy/manage/services/TenantManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/TenantManagement.java
@@ -16,15 +16,17 @@
 
 package com.rackspace.salus.policy.manage.services;
 
+import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import com.rackspace.salus.telemetry.messaging.TenantPolicyChangeEvent;
-import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
-import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -50,6 +52,15 @@ public class TenantManagement {
   public Optional<TenantMetadata> getMetadata(String tenantId) {
     return tenantMetadataRepository.findByTenantId(tenantId);
   }
+  /**
+   * Gets all known tenant metadata for a single tenant.
+   * @param page The slice of results to be returned.
+   * @return A Page of tenant metadata.
+   */
+  public Page<TenantMetadata> getAllMetadata(Pageable page) {
+    return tenantMetadataRepository.findAll(page);
+  }
+
 
   /**
    * Get the account type value for a tenant if it is set.

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -20,15 +20,18 @@ import com.rackspace.salus.policy.manage.services.TenantManagement;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataDTO;
 import com.rackspace.salus.telemetry.model.NotFoundException;
+import com.rackspace.salus.telemetry.model.PagedContent;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -55,6 +58,22 @@ public class TenantApiController {
     return new TenantMetadataDTO(
         tenantManagement.getMetadata(tenantId).orElseThrow(
             () -> new NotFoundException(String.format("No metadata found for tenant %s", tenantId))));
+  }
+
+  @GetMapping("/admin/tenant-metadata")
+  @ApiOperation(value = "Retrieves miscellaneous information stored for all tenants")
+  @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved tenant metadata")})
+  public PagedContent<TenantMetadataDTO> getAllTenantMetadata(Pageable page) {
+    return PagedContent.fromPage(tenantManagement.getAllMetadata(page)
+        .map(TenantMetadataDTO::new));
+  }
+
+  @PostMapping("/admin/tenant-metadata")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Creates information stored for a particular tenant")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully created tenant metadata")})
+  public TenantMetadataDTO createTenantMetadata(@RequestBody TenantMetadataCU input) {
+    return new TenantMetadataDTO(tenantManagement.upsertTenantMetadata(input.getTenantId(), input));
   }
 
   @PutMapping("/admin/tenant-metadata/{tenantId}")

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -48,7 +48,7 @@ public class TenantApiController {
     this.tenantManagement = tenantManagement;
   }
 
-  @GetMapping("/admin/account/{tenantId}")
+  @GetMapping("/admin/tenant-metadata/{tenantId}")
   @ApiOperation(value = "Retrieves miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved tenant metadata")})
   public TenantMetadataDTO getTenantMetadata(@PathVariable String tenantId) {
@@ -57,7 +57,7 @@ public class TenantApiController {
             () -> new NotFoundException(String.format("No metadata found for tenant %s", tenantId))));
   }
 
-  @PutMapping("/admin/account/{tenantId}")
+  @PutMapping("/admin/tenant-metadata/{tenantId}")
   @ApiOperation(value = "Creates or updates miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully updated tenant metadata")})
   public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
@@ -65,7 +65,7 @@ public class TenantApiController {
     return new TenantMetadataDTO(tenantManagement.upsertTenantMetadata(tenantId, input));
   }
 
-  @DeleteMapping("/admin/account/{tenantId}")
+  @DeleteMapping("/admin/tenant-metadata/{tenantId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes all tenant metadata for an account")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Successfully removed tenant metadata")})

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/TenantApiController.java
@@ -48,7 +48,7 @@ public class TenantApiController {
     this.tenantManagement = tenantManagement;
   }
 
-  @GetMapping("/public/account/{tenantId}")
+  @GetMapping("/admin/account/{tenantId}")
   @ApiOperation(value = "Retrieves miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully retrieved tenant metadata")})
   public TenantMetadataDTO getTenantMetadata(@PathVariable String tenantId) {
@@ -57,7 +57,7 @@ public class TenantApiController {
             () -> new NotFoundException(String.format("No metadata found for tenant %s", tenantId))));
   }
 
-  @PutMapping("/public/account/{tenantId}")
+  @PutMapping("/admin/account/{tenantId}")
   @ApiOperation(value = "Creates or updates miscellaneous information stored for a particular tenant")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Successfully updated tenant metadata")})
   public TenantMetadataDTO upsertTenantMetadata(@PathVariable String tenantId,
@@ -65,7 +65,7 @@ public class TenantApiController {
     return new TenantMetadataDTO(tenantManagement.upsertTenantMetadata(tenantId, input));
   }
 
-  @DeleteMapping("/public/account/{tenantId}")
+  @DeleteMapping("/admin/account/{tenantId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @ApiOperation(value = "Deletes all tenant metadata for an account")
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Successfully removed tenant metadata")})

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataCU.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/TenantMetadataCU.java
@@ -16,12 +16,14 @@
 
 package com.rackspace.salus.policy.manage.web.model;
 
+import java.util.HashMap;
 import java.util.Map;
 import lombok.Data;
 
 @Data
 public class TenantMetadataCU {
+  String tenantId; // only used in POST requests
   String accountType;
-  Map<String,String> metadata;
+  Map<String,String> metadata = new HashMap<>();
 
 }

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -27,6 +27,7 @@ import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyDTO;
 import com.rackspace.salus.telemetry.model.MetadataValueType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.TargetClassName;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +36,7 @@ import org.springframework.boot.autoconfigure.cache.CacheType;
 import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
 import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -68,6 +70,9 @@ public class PolicyApiClientTest {
 
   @Autowired
   PolicyApi policyApiClient;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/MetadataPolicyApiControllerTest.java
@@ -42,6 +42,7 @@ import com.rackspace.salus.telemetry.model.MetadataValueType;
 import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.model.TargetClassName;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,6 +76,9 @@ public class MetadataPolicyApiControllerTest {
 
   @MockBean
   MonitorMetadataPolicyManagement monitorMetadataPolicyManagement;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testGetById() throws Exception {

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
@@ -36,6 +36,7 @@ import com.rackspace.salus.telemetry.model.PolicyScope;
 import com.rackspace.salus.telemetry.entities.MonitorPolicy;
 import com.rackspace.salus.policy.manage.services.MonitorPolicyManagement;
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +68,9 @@ public class MonitorPolicyApiControllerTest {
 
   @MockBean
   MonitorPolicyManagement monitorPolicyManagement;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
 
   @Test
   public void testGetById() throws Exception {

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import com.rackspace.salus.policy.manage.services.TenantManagement;
 import com.rackspace.salus.policy.manage.web.model.TenantMetadataCU;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
 import edu.emory.mathcs.backport.java.util.Collections;
 import java.time.Instant;
 import java.util.Optional;
@@ -67,6 +68,9 @@ public class TenantApiControllerTest {
   @MockBean
   TenantManagement tenantManagement;
 
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
+
   @Test
   public void testGetMetadata() throws Exception {
     TenantMetadata metadata = new TenantMetadata()
@@ -81,7 +85,7 @@ public class TenantApiControllerTest {
         .thenReturn(Optional.of(metadata));
 
     mvc.perform(get(
-        "/api/public/account/{tenantId}", metadata.getTenantId())
+        "/api/admin/account/{tenantId}", metadata.getTenantId())
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isOk())
@@ -109,7 +113,7 @@ public class TenantApiControllerTest {
 
     TenantMetadataCU createOrUpdate = podamFactory.manufacturePojo(TenantMetadataCU.class);
     mvc.perform(put(
-        "/api/public/account/{tenantId}", metadata.getTenantId())
+        "/api/admin/account/{tenantId}", metadata.getTenantId())
         .content(objectMapper.writeValueAsString(createOrUpdate))
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
@@ -128,7 +132,7 @@ public class TenantApiControllerTest {
   public void testRemoveMetadata() throws Exception {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
     mvc.perform(delete(
-        "/api/public/account/{tenantId}", tenantId)
+        "/api/admin/account/{tenantId}", tenantId)
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isNoContent());

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantApiControllerTest.java
@@ -85,7 +85,7 @@ public class TenantApiControllerTest {
         .thenReturn(Optional.of(metadata));
 
     mvc.perform(get(
-        "/api/admin/account/{tenantId}", metadata.getTenantId())
+        "/api/admin/tenant-metadata/{tenantId}", metadata.getTenantId())
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isOk())
@@ -113,7 +113,7 @@ public class TenantApiControllerTest {
 
     TenantMetadataCU createOrUpdate = podamFactory.manufacturePojo(TenantMetadataCU.class);
     mvc.perform(put(
-        "/api/admin/account/{tenantId}", metadata.getTenantId())
+        "/api/admin/tenant-metadata/{tenantId}", metadata.getTenantId())
         .content(objectMapper.writeValueAsString(createOrUpdate))
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
@@ -132,7 +132,7 @@ public class TenantApiControllerTest {
   public void testRemoveMetadata() throws Exception {
     String tenantId = RandomStringUtils.randomAlphabetic(10);
     mvc.perform(delete(
-        "/api/admin/account/{tenantId}", tenantId)
+        "/api/admin/tenant-metadata/{tenantId}", tenantId)
         .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isNoContent());

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantVerificationTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantVerificationTest.java
@@ -66,7 +66,7 @@ public class TenantVerificationTest {
     when(tenantMetadataRepository.existsByTenantId(tenantId))
         .thenReturn(true);
 
-    mvc.perform(delete("/api/admin/account/{tenantId}", tenantId)
+    mvc.perform(delete("/api/admin/tenant-metadata/{tenantId}", tenantId)
         // header must be set to trigger tenant verification
         .header(TenantVerification.HEADER_TENANT, tenantId)
         .contentType(MediaType.APPLICATION_JSON))
@@ -82,7 +82,7 @@ public class TenantVerificationTest {
     when(tenantMetadataRepository.existsByTenantId(tenantId))
         .thenReturn(false);
 
-    mvc.perform(delete("/api/admin/account/{tenantId}", tenantId)
+    mvc.perform(delete("/api/admin/tenant-metadata/{tenantId}", tenantId)
         // header must be set to trigger tenant verification
         .header(TenantVerification.HEADER_TENANT, tenantId)
         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantVerificationTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/TenantVerificationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.policy.manage.web.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rackspace.salus.policy.manage.services.TenantManagement;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import com.rackspace.salus.telemetry.web.TenantVerification;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(TenantApiController.class)
+/**
+ * Tenant Verification is currently not used within Policy Management since only admin
+ * api endpoints are available.
+ * If public endpoints are created this test ensures that it will work.
+ */
+public class TenantVerificationTest {
+
+  @Autowired
+  MockMvc mvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @MockBean
+  TenantManagement tenantManagement;
+
+  @MockBean
+  TenantMetadataRepository tenantMetadataRepository;
+
+  @Test
+  public void testTenantVerification_Success() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    when(tenantMetadataRepository.existsByTenantId(tenantId))
+        .thenReturn(true);
+
+    mvc.perform(delete("/api/admin/account/{tenantId}", tenantId)
+        // header must be set to trigger tenant verification
+        .header(TenantVerification.HEADER_TENANT, tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNoContent());
+
+    verify(tenantMetadataRepository).existsByTenantId(tenantId);
+  }
+
+  @Test
+  public void testTenantVerification_Fail() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+
+    when(tenantMetadataRepository.existsByTenantId(tenantId))
+        .thenReturn(false);
+
+    mvc.perform(delete("/api/admin/account/{tenantId}", tenantId)
+        // header must be set to trigger tenant verification
+        .header(TenantVerification.HEADER_TENANT, tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.message", is(TenantVerification.ERROR_MSG)));
+
+    verify(tenantMetadataRepository).existsByTenantId(tenantId);
+  }
+}


### PR DESCRIPTION
See https://github.com/racker/salus-telemetry-model/pull/124

Utilizes the `@EnableTenantVerification` annotations and adds some simple tests to show it took effect.

For this, I also altered the previously `/public` endpoints to be `/admin`.  At least some changes were needed there and since it's not important to decide what is public/admin right now I just moved them all to admin to play it safe.