### PR TITLE
updated cloudbuild to upload the generated api docs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,3 +51,7 @@ steps:
     volumes:
     - name: user.home
       path: /root
+artifacts:
+  objects:
+    location: 'gs://salus_www/policy_management/'
+    paths: ['target/generated/swagger/converted.html']


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-882

# What

It is making sure that when we build this project that the API docs are hosted in a Google Cloud Storage bucket so that we may reference them. 

# How

Utilizes the Google Cloud build system to upload specific artifacts to a specific cloud storage location. Every build should overwrite the previous file.

## How to test

Check the bucket after a build

# Why

Because we are already using Google Cloud Build to do everything and this seemed like an excellent option till we can integrate fully with the documentation team.