### PR TITLE
Add ability to opt-out of monitor policies

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -32,7 +32,7 @@ import java.util.UUID;
  */
 public interface PolicyApi {
   List<MonitorPolicyDTO> getEffectiveMonitorPoliciesForTenant(String tenantId, boolean useCache);
-  List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean useCache);
+  List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean includeNullMonitors, boolean useCache);
   List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache);
   List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId, boolean useCache);
   Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -100,9 +100,10 @@ public class PolicyApiClient implements PolicyApi {
       condition = "!#useCache", beforeInvocation = true)
   @Cacheable(cacheNames = CACHE_POLICY_IDS, key = "#tenantId",
       condition = "#useCache")
-  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean useCache) {
+  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean includeNullMonitors, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}/policy-ids")
+        .queryParam("includeNullMonitors", includeNullMonitors)
         .build(tenantId)
         .toString();
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiController.java
@@ -40,6 +40,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -83,8 +84,9 @@ public class MonitorPolicyApiController {
   @GetMapping("/admin/policy/monitors/effective/{tenantId}/policy-ids")
   @ApiOperation(value = "Gets effective policy monitor ids by tenant id")
   @ApiResponses(value = { @ApiResponse(code = 200, message = "Monitor Policy ids retrieved")})
-  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(@PathVariable String tenantId) {
-    return monitorPolicyManagement.getEffectiveMonitorPolicyIdsForTenant(tenantId);
+  public List<UUID> getEffectiveMonitorPolicyIdsForTenant(@PathVariable String tenantId,
+      @RequestParam(required = false, defaultValue = "true") boolean includeNullMonitors) {
+    return monitorPolicyManagement.getEffectiveMonitorPolicyIdsForTenant(tenantId, includeNullMonitors);
   }
 
   @GetMapping("/admin/policy/monitors")
@@ -118,5 +120,17 @@ public class MonitorPolicyApiController {
   @ApiResponses(value = { @ApiResponse(code = 204, message = "Monitor Policy Deleted")})
   public void delete(@PathVariable UUID uuid) {
     monitorPolicyManagement.removeMonitorPolicy(uuid);
+  }
+
+  @PostMapping("/admin/policy/monitors/opt-out")
+  @ResponseStatus(HttpStatus.CREATED)
+  @ApiOperation(value = "Opt-out of an existing Monitor Policy")
+  @ApiResponses(value = { @ApiResponse(code = 201, message = "Successfully opted out of Monitor Policy")})
+  public MonitorPolicyDTO optOut(@Valid @RequestBody final MonitorPolicyCreate input)
+      throws IllegalArgumentException {
+    if (input.getMonitorId() != null) {
+      throw new IllegalArgumentException("monitorId cannot be set when opting out of policy");
+    }
+    return new MonitorPolicyDTO(monitorPolicyManagement.createMonitorPolicy(input));
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyCreate.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/MonitorPolicyCreate.java
@@ -38,6 +38,5 @@ public class MonitorPolicyCreate implements Serializable {
   @NotBlank
   String name;
 
-  @NotNull
   UUID monitorId;
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/model/validator/MonitorPolicyCreateValidator.java
@@ -18,9 +18,16 @@ package com.rackspace.salus.policy.manage.web.model.validator;
 
 import com.rackspace.salus.policy.manage.web.model.MonitorPolicyCreate;
 import com.rackspace.salus.telemetry.model.PolicyScope;
+import javax.validation.ConstraintValidatorContext;
 import org.apache.commons.lang3.StringUtils;
 
 public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyCreate> {
+
+  @Override
+  public boolean isValid(MonitorPolicyCreate policy, ConstraintValidatorContext context) {
+    return isValidMonitorId(policy) && super.isValid(policy, context);
+  }
+
   @Override
   protected PolicyScope getScope(MonitorPolicyCreate policy) {
     return policy.getScope();
@@ -29,5 +36,16 @@ public class MonitorPolicyCreateValidator extends PolicyValidator<MonitorPolicyC
   @Override
   protected boolean isSubscopeSet(MonitorPolicyCreate policy) {
     return StringUtils.isNotBlank(policy.getSubscope());
+  }
+
+  /**
+   * Validated the monitorId value is correct.
+   * Monitor Id is optional for Tenant policies but required for any other scope.
+   *
+   * @param policy The policy to validate.
+   * @return True if the policy is valid, otherwise false.
+   */
+  private boolean isValidMonitorId(MonitorPolicyCreate policy) {
+    return policy.getScope() == PolicyScope.TENANT || policy.getMonitorId() != null;
   }
 }

--- a/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/controller/MonitorPolicyApiControllerTest.java
@@ -18,6 +18,7 @@ package com.rackspace.salus.policy.manage.web.controller;
 
 import static com.rackspace.salus.test.JsonTestUtils.readContent;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -116,6 +117,47 @@ public class MonitorPolicyApiControllerTest {
         .andExpect(content().json(objectMapper.writeValueAsString(listOfPolicies)));
 
     verify(monitorPolicyManagement).getEffectiveMonitorPoliciesForTenant(tenantId);
+    verifyNoMoreInteractions(monitorPolicyManagement);
+  }
+
+  @Test
+  public void testGetEffectivePolicyIdsByTenantId() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    final List<UUID> listOfPolicyIds = podamFactory.manufacturePojo(ArrayList.class, UUID.class);
+    when(monitorPolicyManagement.getEffectiveMonitorPolicyIdsForTenant(anyString(), anyBoolean()))
+        .thenReturn(listOfPolicyIds);
+
+    mvc.perform(get(
+        "/api/admin/policy/monitors/effective/{tenantId}/policy-ids", tenantId)
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(objectMapper.writeValueAsString(listOfPolicyIds)));
+
+    verify(monitorPolicyManagement).getEffectiveMonitorPolicyIdsForTenant(tenantId, true);
+    verifyNoMoreInteractions(monitorPolicyManagement);
+  }
+
+  @Test
+  public void testGetEffectivePolicyIdsByTenantId_excludeNull() throws Exception {
+    String tenantId = RandomStringUtils.randomAlphabetic(10);
+    final List<UUID> listOfPolicyIds = podamFactory.manufacturePojo(ArrayList.class, UUID.class);
+    when(monitorPolicyManagement.getEffectiveMonitorPolicyIdsForTenant(anyString(), anyBoolean()))
+        .thenReturn(listOfPolicyIds);
+
+    mvc.perform(get(
+        "/api/admin/policy/monitors/effective/{tenantId}/policy-ids", tenantId)
+        .queryParam("includeNullMonitors", "false")
+        .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(content()
+            .contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+        .andExpect(content().json(objectMapper.writeValueAsString(listOfPolicyIds)));
+
+    verify(monitorPolicyManagement).getEffectiveMonitorPolicyIdsForTenant(tenantId, false);
     verifyNoMoreInteractions(monitorPolicyManagement);
   }
 


### PR DESCRIPTION
# How

Allow for `null` monitorIds to be set in policies - but only for `Tenant` scoped policies, which therefore means only for opting out of global or accountType scopes policies.

Also adds an endpoint to assist in opting out.  It's very similar to creating a policy but hopefully helps remove any expectation that you know an opt-out is the same as creating a `null` policy.  Instead you can see the opt-out endpoint exists and know that it can be used.

Also updated `getEffectiveMonitorPolicyIdsForTenant` to be able to either include or exclude policies that have `null` monitorIds.  This simplifies the logic required in other services such as MonitorManagement.  You would still want an API endpoint that returns all policies for a tenant including those that are used to opt-out, but for various other internal logic it is helpful to ignore any null policies.

# Why

Customer's will be automatically included in certain policies, such as Ping monitoring for all devices.  If they need to remove that functionality they will need to ask their support team to opt-out of it for them.