### PR TITLE
Make sure Client calls are not encoded

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -84,7 +84,7 @@ public class PolicyApiClient implements PolicyApi {
       condition = "#useCache")
   public List<MonitorPolicyDTO> getEffectiveMonitorPoliciesForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
-        .fromUriString("/api/admin/policy/monitors/effective/{tenantId}")
+        .fromPath("/api/admin/policy/monitors/effective/{tenantId}")
         .buildAndExpand(tenantId)
         .toString();
 

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -84,8 +84,8 @@ public class PolicyApiClient implements PolicyApi {
       condition = "#useCache")
   public List<MonitorPolicyDTO> getEffectiveMonitorPoliciesForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
-        .fromPath("/api/admin/policy/monitors/effective/{tenantId}")
-        .build(tenantId)
+        .fromUriString("/api/admin/policy/monitors/effective/{tenantId}")
+        .buildAndExpand(tenantId)
         .toString();
 
     return restTemplate.exchange(
@@ -103,7 +103,7 @@ public class PolicyApiClient implements PolicyApi {
   public List<UUID> getEffectiveMonitorPolicyIdsForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}/policy-ids")
-        .build(tenantId)
+        .buildAndExpand(tenantId)
         .toString();
 
     return restTemplate.exchange(
@@ -121,7 +121,7 @@ public class PolicyApiClient implements PolicyApi {
   public List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/monitors/effective/{tenantId}/monitor-ids")
-        .build(tenantId)
+        .buildAndExpand(tenantId)
         .toString();
 
     return restTemplate.exchange(
@@ -140,7 +140,7 @@ public class PolicyApiClient implements PolicyApi {
       String tenantId, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}")
-        .build(tenantId)
+        .buildAndExpand(tenantId)
         .toString();
 
     return restTemplate.exchange(
@@ -159,7 +159,7 @@ public class PolicyApiClient implements PolicyApi {
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
-        .build(tenantId, className, monitorType)
+        .buildAndExpand(tenantId, className, monitorType)
         .toString();
 
     return restTemplate.exchange(
@@ -176,7 +176,7 @@ public class PolicyApiClient implements PolicyApi {
   public List<String> getDefaultMonitoringZones(String region, boolean useCache) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/zones/{region}")
-        .build(region)
+        .buildAndExpand(region)
         .toString();
 
     return restTemplate.exchange(

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -93,7 +93,7 @@ public class PolicyApiClientTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("PT2S"));
 
-    String tenantId = RandomStringUtils.randomAlphanumeric(10);
+    String tenantId = "hybrid:123456";
 
     mockServer.expect(ExpectedCount.once(),
         requestTo(String.format(
@@ -179,7 +179,7 @@ public class PolicyApiClientTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("PT1M"));
 
-    String tenantId = RandomStringUtils.randomAlphanumeric(10);
+    String tenantId = "hybrid:123456";
 
     // only one of the three requests will hit the cache
     mockServer.expect(ExpectedCount.twice(),

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -132,7 +132,7 @@ public class PolicyApiClientTest {
             .setValueType(MetadataValueType.DURATION)
             .setValue("PT2S"));
 
-    String tenantId = RandomStringUtils.randomAlphanumeric(10);
+    String tenantId = "hybrid:123456";
 
     mockServer.expect(ExpectedCount.twice(),
         requestTo(String.format(


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-892

# What

It makes sure that our values are passed URLDecoded

# How

The Javadoc for `UriComponentsBuilder` is not very clear how `BuildAndExpand` knows to decode the values but it does (or perhaps it never encodes them but I dont think that is likely). It is also how we were constructing values in the other ApiClient classes, so I feel confident that this brings this ApiClient in line with the others.

## How to test

Unit tests have been updated with hybrid:123456 values. So run the unit tests.

# Why

I created a PR for building out a Filter to make sure that communication coming in is UrlDecode'ed, I am not sure if we want that anymore. This makes sure the Client sends the correct data in the first place.
