### PR TITLE
Generate policy events for all known tenants

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -70,7 +70,7 @@ public class PolicyManagement {
    */
   List<String> getAllDistinctTenantIds() {
     return entityManager
-        .createNamedQuery("Resource.getAllDistinctTenants", String.class)
+        .createNamedQuery("TenantMetadata.getAllDistinctTenants", String.class)
         .getResultList();
   }
 

--- a/src/test/java/com/rackspace/salus/policy/manage/TestUtility.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/TestUtility.java
@@ -17,13 +17,14 @@
 package com.rackspace.salus.policy.manage;
 
 import com.rackspace.salus.telemetry.entities.Monitor;
-import com.rackspace.salus.telemetry.entities.Resource;
+import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import com.rackspace.salus.telemetry.repositories.MonitorRepository;
-import com.rackspace.salus.telemetry.repositories.ResourceRepository;
+import com.rackspace.salus.telemetry.repositories.TenantMetadataRepository;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
 
@@ -37,20 +38,32 @@ public class TestUtility {
     return monitorRepository.save(monitor);
   }
 
-  public static String createSingleTenant(ResourceRepository resourceRepository) {
-    Resource resource = podamFactory.manufacturePojo(Resource.class);
-    resource.setResourceId(RandomStringUtils.randomAlphabetic(10));
-    return resourceRepository.save(resource).getTenantId();
+  public static String createSingleTenant(TenantMetadataRepository tenantRepository) {
+      TenantMetadata tenantMetadata = podamFactory.manufacturePojo(TenantMetadata.class);
+      tenantMetadata.setTenantId(RandomStringUtils.randomAlphanumeric(10));
+      return tenantRepository.save(tenantMetadata).getTenantId();
   }
 
-  public static List<String> createMultipleTenants(ResourceRepository resourceRepository) {
-    return createMultipleTenants(resourceRepository, 5);
+  public static List<String> createMultipleTenants(TenantMetadataRepository tenantRepository) {
+    return createMultipleTenants(tenantRepository, 5);
   }
 
-  public static List<String> createMultipleTenants(ResourceRepository resourceRepository, int count) {
+  public static List<String> createMultipleTenants(TenantMetadataRepository tenantRepository, int count) {
     return IntStream.range(0, count)
-        .mapToObj(i -> createSingleTenant(resourceRepository))
+        .mapToObj(i -> createSingleTenant(tenantRepository))
         .collect(Collectors.toList());
   }
 
+  public static String createTenantOfAccountType(TenantMetadataRepository tenantRepository, String accountType) {
+    return tenantRepository.save(new TenantMetadata()
+        .setAccountType(accountType)
+        .setTenantId(RandomStringUtils.randomAlphanumeric(10))
+        .setMetadata(Collections.emptyMap())).getTenantId();
+  }
+
+  public static List<String> createTenantsOfAccountType(TenantMetadataRepository tenantRepository, int count, String accountType) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> createTenantOfAccountType(tenantRepository, accountType))
+        .collect(Collectors.toList());
+  }
 }

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
@@ -38,7 +38,6 @@ import com.rackspace.salus.policy.manage.web.model.MonitorMetadataPolicyCreate;
 import com.rackspace.salus.telemetry.entities.MetadataPolicy;
 import com.rackspace.salus.telemetry.entities.MonitorMetadataPolicy;
 import com.rackspace.salus.telemetry.entities.Policy;
-import com.rackspace.salus.policy.manage.services.MonitorPolicyManagementTest.*;
 import com.rackspace.salus.telemetry.entities.TenantMetadata;
 import com.rackspace.salus.telemetry.errors.AlreadyExistsException;
 import com.rackspace.salus.telemetry.messaging.MetadataPolicyEvent;
@@ -60,7 +59,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.persistence.EntityManager;
 import javax.persistence.TypedQuery;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -199,7 +197,7 @@ public class MonitorMetadataPolicyManagementTest {
 
   @Test
   public void testCreateMetadataPolicy_multipleTenants() {
-    List<String> tenantIds = TestUtility.createMultipleTenants(resourceRepository);
+    List<String> tenantIds = TestUtility.createMultipleTenants(tenantMetadataRepository);
 
     MonitorMetadataPolicyCreate policyCreate = (MonitorMetadataPolicyCreate) new MonitorMetadataPolicyCreate()
         .setMonitorType(MonitorType.ssl)
@@ -475,7 +473,7 @@ public class MonitorMetadataPolicyManagementTest {
 
   @Test
   public void testRemoveMetadataPolicy() {
-    String tenantId = TestUtility.createSingleTenant(resourceRepository);
+    String tenantId = TestUtility.createSingleTenant(tenantMetadataRepository);
 
     // Create a policy to remove
     MetadataPolicy saved = (MetadataPolicy) policyRepository.save(new MonitorMetadataPolicy()


### PR DESCRIPTION
# Resolves

https://jira.rax.io/browse/SALUS-872

# What

Updates the query for getting all tenantIds to match the change in https://github.com/racker/salus-telemetry-model/pull/136

With this change tests needed to be updated to create tenants in the tenant-metadata table vs. creating a resource for the tenant.