### PR TITLE
Metadata policy is being cashed even after deletion

### DIFF
--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
@@ -236,8 +236,6 @@ public class MonitorMetadataPolicyManagement {
 
     monitorMetadataPolicyRepository.deleteById(id);
     log.info("Removed policy {}", policy);
-    policyManagement.getTenantsForPolicy(policy)
-        .forEach(e -> policyManagement.removePolicyFromCache(e, policy.getTargetClassName(), policy.getMonitorType()));
     sendMetadataPolicyEvents(policy);
     createMonitorMetadataPolicySuccess
         .tags(MetricTags.OPERATION_METRIC_TAG, MetricTagValues.REMOVE_OPERATION, MetricTags.OBJECT_TYPE_METRIC_TAG,"metadataPolicy")
@@ -267,8 +265,10 @@ public class MonitorMetadataPolicyManagement {
 
     tenantIds.stream()
         .map(tenantId -> new MetadataPolicyEvent()
-            .setPolicyId(policy.getId())
-            .setTenantId(tenantId))
+            .setMonitorType(policy.getMonitorType())
+            .setTargetClassName(policy.getTargetClassName())
+            .setTenantId(tenantId)
+            .setPolicyId(policy.getId()))
         .forEach(policyEventProducer::sendPolicyEvent);
   }
 

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
@@ -48,6 +48,7 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -63,6 +64,8 @@ public class MonitorMetadataPolicyManagement {
 
   MeterRegistry meterRegistry;
 
+  CacheManager cacheManager;
+
   // metrics counters
   private final Counter.Builder createMonitorMetadataPolicySuccess;
 
@@ -70,7 +73,8 @@ public class MonitorMetadataPolicyManagement {
       EntityManager entityManager,
       MonitorMetadataPolicyRepository monitorMetadataPolicyRepository,
       PolicyEventProducer policyEventProducer,
-      PolicyManagement policyManagement, MeterRegistry meterRegistry) {
+      PolicyManagement policyManagement, MeterRegistry meterRegistry,
+      CacheManager cacheManager) {
     this.entityManager = entityManager;
     this.monitorMetadataPolicyRepository = monitorMetadataPolicyRepository;
     this.policyEventProducer = policyEventProducer;
@@ -79,6 +83,7 @@ public class MonitorMetadataPolicyManagement {
     this.meterRegistry = meterRegistry;
     createMonitorMetadataPolicySuccess = Counter.builder(MetricNames.SERVICE_OPERATION_SUCCEEDED)
         .tag(MetricTags.SERVICE_METRIC_TAG,"MonitorMetadataPolicyManagement");
+    this.cacheManager = cacheManager;
   }
 
   /**
@@ -231,6 +236,8 @@ public class MonitorMetadataPolicyManagement {
 
     monitorMetadataPolicyRepository.deleteById(id);
     log.info("Removed policy {}", policy);
+    policyManagement.getTenantsForPolicy(policy)
+        .forEach(e -> policyManagement.removePolicyFromCache(e, policy.getTargetClassName(), policy.getMonitorType()));
     sendMetadataPolicyEvents(policy);
     createMonitorMetadataPolicySuccess
         .tags(MetricTags.OPERATION_METRIC_TAG, MetricTagValues.REMOVE_OPERATION, MetricTags.OBJECT_TYPE_METRIC_TAG,"metadataPolicy")

--- a/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagement.java
@@ -48,7 +48,6 @@ import javax.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.boot.context.properties.PropertyMapper;
-import org.springframework.cache.CacheManager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -64,8 +63,6 @@ public class MonitorMetadataPolicyManagement {
 
   MeterRegistry meterRegistry;
 
-  CacheManager cacheManager;
-
   // metrics counters
   private final Counter.Builder createMonitorMetadataPolicySuccess;
 
@@ -73,8 +70,7 @@ public class MonitorMetadataPolicyManagement {
       EntityManager entityManager,
       MonitorMetadataPolicyRepository monitorMetadataPolicyRepository,
       PolicyEventProducer policyEventProducer,
-      PolicyManagement policyManagement, MeterRegistry meterRegistry,
-      CacheManager cacheManager) {
+      PolicyManagement policyManagement, MeterRegistry meterRegistry) {
     this.entityManager = entityManager;
     this.monitorMetadataPolicyRepository = monitorMetadataPolicyRepository;
     this.policyEventProducer = policyEventProducer;
@@ -83,7 +79,6 @@ public class MonitorMetadataPolicyManagement {
     this.meterRegistry = meterRegistry;
     createMonitorMetadataPolicySuccess = Counter.builder(MetricNames.SERVICE_OPERATION_SUCCEEDED)
         .tag(MetricTags.SERVICE_METRIC_TAG,"MonitorMetadataPolicyManagement");
-    this.cacheManager = cacheManager;
   }
 
   /**

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -16,12 +16,8 @@
 
 package com.rackspace.salus.policy.manage.services;
 
-import static com.rackspace.salus.policy.manage.web.client.PolicyApiCacheConfig.CACHE_MONITOR_METADATA_MAP;
-
 import com.rackspace.salus.telemetry.entities.Policy;
-import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
-import com.rackspace.salus.telemetry.model.TargetClassName;
 import com.rackspace.salus.telemetry.repositories.PolicyRepository;
 import java.util.Collections;
 import java.util.List;
@@ -29,7 +25,6 @@ import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -101,11 +96,5 @@ public class PolicyManagement {
     return policy.getScope().equals(PolicyScope.GLOBAL) ||
         (policy.getScope().equals(PolicyScope.ACCOUNT_TYPE) && policy.getSubscope().equals(accountType)) ||
         (policy.getScope().equals(PolicyScope.TENANT) && policy.getSubscope().equals(tenantId));
-  }
-
-  @CacheEvict(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}",
-      beforeInvocation = true)
-  public void removePolicyFromCache(String tenantId, TargetClassName className, MonitorType monitorType) {
-    log.info("cache removed for tenantId={}, className={}, monitorType={} ", tenantId, className, monitorType);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -16,17 +16,24 @@
 
 package com.rackspace.salus.policy.manage.services;
 
+import static com.rackspace.salus.policy.manage.web.client.PolicyApiCacheConfig.CACHE_MONITOR_METADATA_MAP;
+
 import com.rackspace.salus.telemetry.entities.Policy;
+import com.rackspace.salus.telemetry.model.MonitorType;
 import com.rackspace.salus.telemetry.model.PolicyScope;
+import com.rackspace.salus.telemetry.model.TargetClassName;
 import com.rackspace.salus.telemetry.repositories.PolicyRepository;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class PolicyManagement {
 
   private final PolicyRepository policyRepository;
@@ -94,5 +101,11 @@ public class PolicyManagement {
     return policy.getScope().equals(PolicyScope.GLOBAL) ||
         (policy.getScope().equals(PolicyScope.ACCOUNT_TYPE) && policy.getSubscope().equals(accountType)) ||
         (policy.getScope().equals(PolicyScope.TENANT) && policy.getSubscope().equals(tenantId));
+  }
+
+  @CacheEvict(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}",
+      beforeInvocation = true)
+  public void removePolicyFromCache(String tenantId, TargetClassName className, MonitorType monitorType) {
+    log.info("cache removed for tenantId={}, className={}, monitorType={} ", tenantId, className, monitorType);
   }
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/services/PolicyManagement.java
@@ -24,11 +24,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import javax.persistence.EntityManager;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Service
-@Slf4j
 public class PolicyManagement {
 
   private final PolicyRepository policyRepository;

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -36,7 +36,7 @@ public interface PolicyApi {
   List<UUID> getEffectivePolicyMonitorIdsForTenant(String tenantId, boolean useCache);
   List<MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataPolicies(String tenantId, boolean useCache);
   Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
-      String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache);
+      String tenantId, TargetClassName className, MonitorType monitorType);
   List<String> getDefaultMonitoringZones(String region, boolean useCache);
   void evictEffectiveMonitorMetadataMap(String tenantId, TargetClassName className,
       MonitorType monitorType);

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApi.java
@@ -38,4 +38,6 @@ public interface PolicyApi {
   Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache);
   List<String> getDefaultMonitoringZones(String region, boolean useCache);
+  void evictEffectiveMonitorMetadataMap(String tenantId, TargetClassName className,
+      MonitorType monitorType);
 }

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -30,6 +30,7 @@ import com.rackspace.salus.telemetry.model.TargetClassName;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.core.ParameterizedTypeReference;
@@ -66,6 +67,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  *   <code>&#64;Import</code> {@link PolicyApiCacheConfig} on a config bean declaring the client bean.
  * </p>
  */
+@Slf4j
 public class PolicyApiClient implements PolicyApi {
   private static final ParameterizedTypeReference<List<MonitorPolicyDTO>> LIST_OF_MONITOR_POLICY = new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<List<MonitorMetadataPolicyDTO>> LIST_OF_MONITOR_METADATA_POLICY = new ParameterizedTypeReference<>() {};
@@ -158,6 +160,7 @@ public class PolicyApiClient implements PolicyApi {
       condition = "#useCache")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
+    log.info("cache added for tenantId={}, className={}, monitorType={} ", tenantId, className, monitorType);
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
         .buildAndExpand(tenantId, className, monitorType)

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -160,7 +160,6 @@ public class PolicyApiClient implements PolicyApi {
       condition = "#useCache")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
-    log.info("cache added for tenantId={}, className={}, monitorType={} ", tenantId, className, monitorType);
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
         .buildAndExpand(tenantId, className, monitorType)

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -156,7 +156,7 @@ public class PolicyApiClient implements PolicyApi {
 
   @Cacheable(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
-      String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
+      String tenantId, TargetClassName className, MonitorType monitorType) {
     final String uri = UriComponentsBuilder
         .fromPath("/api/admin/policy/metadata/monitor/effective/{tenantId}/{className}/{monitorType}")
         .buildAndExpand(tenantId, className, monitorType)

--- a/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
+++ b/src/main/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClient.java
@@ -154,10 +154,7 @@ public class PolicyApiClient implements PolicyApi {
     ).getBody();
   }
 
-  @CacheEvict(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}",
-      condition = "!#useCache", beforeInvocation = true)
-  @Cacheable(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}",
-      condition = "#useCache")
+  @Cacheable(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}")
   public Map<String, MonitorMetadataPolicyDTO> getEffectiveMonitorMetadataMap(
       String tenantId, TargetClassName className, MonitorType monitorType, boolean useCache) {
     final String uri = UriComponentsBuilder
@@ -171,6 +168,11 @@ public class PolicyApiClient implements PolicyApi {
         null,
         MAP_OF_MONITOR_POLICY
     ).getBody();
+  }
+
+  @CacheEvict(cacheNames = CACHE_MONITOR_METADATA_MAP, key = "{#tenantId, #className, #monitorType}",
+       beforeInvocation = true)
+  public void evictEffectiveMonitorMetadataMap(String tenantId, TargetClassName className, MonitorType monitorType)  {
   }
 
   @CacheEvict(cacheNames = CACHE_ZONE_METADATA, key = "#region", condition = "!#useCache",

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest.java
@@ -189,6 +189,8 @@ public class MonitorMetadataPolicyManagementTest {
 
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.Monitor)
+            .setMonitorType(MonitorType.ping)
             .setPolicyId(policy.getId())
             .setTenantId(tenantId)
     ));
@@ -224,6 +226,8 @@ public class MonitorMetadataPolicyManagementTest {
 
     List<MetadataPolicyEvent> expected = tenantIds.stream()
         .map(t -> (MetadataPolicyEvent) new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.Monitor)
+            .setMonitorType(MonitorType.ssl)
             .setPolicyId(policy.getId())
             .setTenantId(t)).collect(Collectors.toList());
 
@@ -261,6 +265,8 @@ public class MonitorMetadataPolicyManagementTest {
 
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.Monitor)
+            .setMonitorType(MonitorType.net_response)
             .setPolicyId(policy.getId())
             .setTenantId(tenantId)
     ));
@@ -323,6 +329,8 @@ public class MonitorMetadataPolicyManagementTest {
     // Verify the Policy Event looks correct
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.Monitor)
+            .setMonitorType(MonitorType.ping)
             .setPolicyId(policy.getId())
             .setTenantId(tenantId)
     ));
@@ -496,6 +504,8 @@ public class MonitorMetadataPolicyManagementTest {
 
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.Monitor)
+            .setMonitorType(MonitorType.disk)
             .setPolicyId(saved.getId())
             .setTenantId(tenantId)
     ));

--- a/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/services/MonitorMetadataPolicyManagementTest_Zones.java
@@ -145,6 +145,7 @@ public class MonitorMetadataPolicyManagementTest_Zones {
 
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.RemotePlugin)
             .setPolicyId(policy.getId())
             .setTenantId(tenantId)
     ));
@@ -171,6 +172,7 @@ public class MonitorMetadataPolicyManagementTest_Zones {
     verify(policyEventProducer).sendPolicyEvent(policyEventArg.capture());
     assertThat(policyEventArg.getValue(), equalTo(
         new MetadataPolicyEvent()
+            .setTargetClassName(TargetClassName.RemotePlugin)
             .setPolicyId(policy.getId())
             .setTenantId(tenantId)
     ));

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -44,7 +44,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.client.ExpectedCount;
 import org.springframework.test.web.client.MockRestServiceServer;
-import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 
 
 /**

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -133,7 +133,7 @@ public class PolicyApiClientTest {
 
     String tenantId = "hybrid:123456";
 
-    mockServer.expect(ExpectedCount.twice(),
+    mockServer.expect(ExpectedCount.once(),
         requestTo(String.format(
             "/api/admin/policy/metadata/monitor/effective/%s/RemotePlugin/ping", tenantId)))
         .andRespond(withSuccess(
@@ -144,6 +144,8 @@ public class PolicyApiClientTest {
         tenantId, TargetClassName.RemotePlugin, MonitorType.ping, false);
 
     assertThat(policies, equalTo(expectedPolicy));
+
+    policyApiClient.evictEffectiveMonitorMetadataMap(tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     // running the same request again should bypass the cache and perform a full request
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
@@ -181,7 +183,7 @@ public class PolicyApiClientTest {
     String tenantId = "hybrid:123456";
 
     // only one of the three requests will hit the cache
-    mockServer.expect(ExpectedCount.twice(),
+    mockServer.expect(ExpectedCount.once(),
         requestTo(String.format(
             "/api/admin/policy/metadata/monitor/effective/%s/RemotePlugin/ping", tenantId)))
         .andRespond(withSuccess(
@@ -199,6 +201,8 @@ public class PolicyApiClientTest {
         tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
 
     assertThat(policies, equalTo(expectedPingPolicy));
+
+    policyApiClient.evictEffectiveMonitorMetadataMap(tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     // make the same request bypassing the cache
     policies = policyApiClient.getEffectiveMonitorMetadataMap(

--- a/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
+++ b/src/test/java/com/rackspace/salus/policy/manage/web/client/PolicyApiClientTest.java
@@ -102,13 +102,13 @@ public class PolicyApiClientTest {
         ));
 
     Map<String, MonitorMetadataPolicyDTO> policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPolicy));
 
     // running the same request again should return the same result from the cache
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPolicy));
     mockServer.verify();
@@ -141,7 +141,7 @@ public class PolicyApiClientTest {
         ));
 
     Map<String, MonitorMetadataPolicyDTO> policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, false);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPolicy));
 
@@ -149,7 +149,7 @@ public class PolicyApiClientTest {
 
     // running the same request again should bypass the cache and perform a full request
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, false);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPolicy));
     mockServer.verify();
@@ -192,13 +192,13 @@ public class PolicyApiClientTest {
 
     // first request will populate the cache
     Map<String, MonitorMetadataPolicyDTO> policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPingPolicy));
 
     // make the same request using the cache
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPingPolicy));
 
@@ -206,7 +206,7 @@ public class PolicyApiClientTest {
 
     // make the same request bypassing the cache
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.ping, false);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.ping);
 
     assertThat(policies, equalTo(expectedPingPolicy));
 
@@ -225,15 +225,15 @@ public class PolicyApiClientTest {
     // Run the request for a different monitor type 3 times using the cache
     // the same result will be returned each time
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.http, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.http);
     assertThat(policies, equalTo(expectedHttpPolicy));
 
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.http, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.http);
     assertThat(policies, equalTo(expectedHttpPolicy));
 
     policies = policyApiClient.getEffectiveMonitorMetadataMap(
-        tenantId, TargetClassName.RemotePlugin, MonitorType.http, true);
+        tenantId, TargetClassName.RemotePlugin, MonitorType.http);
     assertThat(policies, equalTo(expectedHttpPolicy));
 
     mockServer.verify();


### PR DESCRIPTION
# Resolves

[SALUS-1033](https://jira.rax.io/browse/SALUS-1033)

# What

BugFix - Metadata policy is being cashed even after deletion

# Depends On

https://github.com/racker/salus-telemetry-monitor-management/pull/227
https://github.com/racker/salus-telemetry-model/pull/171